### PR TITLE
Netty bson constructer bug fixed and BufferTests fixed

### DIFF
--- a/src/main/scala/io/boson/nettybson/NettyBson.scala
+++ b/src/main/scala/io/boson/nettybson/NettyBson.scala
@@ -45,29 +45,32 @@ class NettyBson(byteArray: Option[Array[Byte]] = None, byteBuf: Option[ByteBuf] 
 
   private val nettyBuffer: ByteBuf = valueOfArgument match {
     case NETTY_READONLY_BUF => // Netty
-      val b = Unpooled.buffer()
-      b.writeBytes(byteBuf.get)
+      val b = byteBuf.get.duplicate()
+      //Unpooled.buffer()
+      b//.writeBytes(byteBuf.get)
     case NETTY_DEFAULT_BUF => // Netty
-      val b = Unpooled.buffer()
-      b.writeBytes(byteBuf.get)
+      val b = byteBuf.get.duplicate()
+      //Unpooled.buffer()
+      b///.writeBytes(byteBuf.get)
     case ARRAY_BYTE => // Array[Byte]
-      val b = Unpooled.buffer()
-      b.writeBytes(byteArray.get)
+      val b = Unpooled.copiedBuffer(byteArray.get)
+      // b.writeBytes(byteArray.get)
+      b
     case JAVA_BYTEBUFFER => // Java ByteBuffer
-      val b = Unpooled.buffer()
-      //javaByteBuf.get.flip()
-      b.writeBytes(javaByteBuf.get)
+      val b = Unpooled.copiedBuffer(javaByteBuf.get)
       javaByteBuf.get.clear()
       b
     case VERTX_BUF => // Vertx Buffer
-      val b = Unpooled.buffer()
-      b.writeBytes(vertxBuff.get.getBytes)
+      println("Vertx buffer")
+      val b = vertxBuff.get.getByteBuf
+      b//.writeBytes(vertxBuff.get.getBytes)
     case SCALA_ARRAYBUF => // Scala ArrayBuffer[Byte]
-      val b = Unpooled.buffer()
-      b.writeBytes(scalaArrayBuf.get.toArray)
+      val b = Unpooled.copiedBuffer(scalaArrayBuf.get.toArray)
+      b//.writeBytes(scalaArrayBuf.get.toArray)
     case NETTY_DUPLICATED_BUF => // Netty
-      val b = Unpooled.buffer()
-      b.writeBytes(byteBuf.get)
+      val b = byteBuf.get.duplicate()
+      //Unpooled.buffer()
+      b//.writeBytes(byteBuf.get)
     case EMPTY_CONSTRUCTOR =>
       Unpooled.buffer()
   }

--- a/src/test/scala/io/boson/BuffersTest.scala
+++ b/src/test/scala/io/boson/BuffersTest.scala
@@ -3,6 +3,7 @@ package io.boson
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 
+import com.sun.corba.se.impl.transport.ByteBufferPoolImpl
 import io.boson.bson.BsonObject
 import io.boson.nettybson.NettyBson
 import io.vertx.core.buffer.Buffer
@@ -20,19 +21,20 @@ class BuffersTest extends FunSuite {
   val exampleNetty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
 
   test("Java ByteBuffer"){
-    val javaBuffer: ByteBuffer = ByteBuffer.allocate(256)
-    javaBuffer.put(bsonEvent.encode().getBytes)
+    val array: Array[Byte] = bsonEvent.encode().getBytes
+    val javaBuffer: ByteBuffer = ByteBuffer.allocate(array.size)
+    javaBuffer.put(array)
     javaBuffer.flip()
     val nettyFromJava = new NettyBson(javaByteBuf = Option(javaBuffer))
-    assert(new String(javaBuffer.array()) === new String(nettyFromJava.getByteBuf.array())
+    assert(javaBuffer.array() === nettyFromJava.getByteBuf.array()
       , "Content from ByteBuffer(java) it's different from nettyFromJava")
   }
 
   test("Vertx ByteBuffer"){
-    val vertxBuf: Buffer = Buffer.buffer()
+    val vertxBuf: Buffer = Buffer.buffer(exampleNetty.array.length)
     vertxBuf.appendBytes(exampleNetty.array)
     val nettyFromVertx = new NettyBson(vertxBuff = Option(vertxBuf))
-    assert(new String(vertxBuf.getBytes) === new String(nettyFromVertx.getByteBuf.array())
+    assert(vertxBuf.getBytes === nettyFromVertx.getByteBuf.array()
       , "Content from ByteBuffer(Vertx) it's different from nettyFromVertx")
   }
 

--- a/src/test/scala/io/boson/BuffersTest.scala
+++ b/src/test/scala/io/boson/BuffersTest.scala
@@ -1,9 +1,7 @@
 package io.boson
 
 import java.nio.ByteBuffer
-import java.nio.charset.Charset
 
-import com.sun.corba.se.impl.transport.ByteBufferPoolImpl
 import io.boson.bson.BsonObject
 import io.boson.nettybson.NettyBson
 import io.vertx.core.buffer.Buffer


### PR DESCRIPTION
The creation of new NettyBson from different types of Buffers wasnt working properly due to the function 
writeBytes from netty Library. This was fixed for the different types of buffers accepted.

The tests BufferTest also stop working due to the buffers size of the returning or given buffers. Also fixed. 