### PR TITLE
Interfaces buffer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,5 @@ Lastly its possible to join terms of tables 1, 2 and 3.
 
 ### Available Buffer Types
 * Array of Bytes
-* Netty ByteBuf
 * Java ByteBuffer
-* Vertx Buffer
 * Scala ArrayBuffer

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ val expression: String = "first"
 //  NettyBson is an Object that encapsulates a certain type of buffer
 //  and transforms it into a Netty buffer.
 //  Available types are shown further down in the README document.
-val netty: NettyBson = sI.createNettyBson(bsonObject.encode())
+val netty: NettyBson = sI.createNettyBson(bsonObject.encode().getBytes)
 
 //  To extract from the Netty buffer, method parse is called with the key and expression.
 //  The result can be one of three types depending on the used terms in expression.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ val globalObj: BsonObject = new BsonObject().put("Salary", 1000).put("AnualSalar
     .put("Unemployed", false).put("Residence", "Lisboa").putNull("Experience")
 
 //  Instantiate a NettyBson that receives a buffer containing the Bson encoded
-val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(globalObj.encode()))
+val nettyBson: NettyBson = new NettyBson(byteArray = Option(globalObj.encode().getBytes))
 
 //  Call extract method on nettyBson, the arguments being the netty byteBuf of NettyBson object,
 //  the key of the value to extract, and an expression from Table 1(shwon further down in this document).

--- a/src/main/java/io/boson/bson/BsonArray.java
+++ b/src/main/java/io/boson/bson/BsonArray.java
@@ -546,6 +546,22 @@ public class BsonArray implements Iterable<Object> {
     }
 
     /**
+     * Encode the BSON array as a Byte Array
+     *
+     * @return the Byte Array
+     */
+    public byte[] encodeToBarray(){
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            Bson.encode(list, os);
+            os.flush();
+            return os.toByteArray();
+        } catch (IOException e) {
+            throw new VertxException(e);
+        }
+    }
+
+    /**
      * Encode this BSON object in an output stream
      *
      * @return the string encoding.

--- a/src/main/java/io/boson/bson/BsonObject.java
+++ b/src/main/java/io/boson/bson/BsonObject.java
@@ -704,6 +704,22 @@ public class BsonObject implements Iterable<Map.Entry<String, Object>> {
         }
     }
 
+    /**
+     * Encode the BSON object as a Byte Array
+     *
+     * @return the Byte Array
+     */
+    public byte[] encodeToBarray(){
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            Bson.encode(map, os);
+            os.flush();
+            return os.toByteArray();
+        } catch (IOException e) {
+            throw new VertxException(e);
+        }
+    }
+
 
     /**
      * Copy the JSON object

--- a/src/main/java/io/boson/javaInterface/JavaInterface.java
+++ b/src/main/java/io/boson/javaInterface/JavaInterface.java
@@ -5,7 +5,6 @@ import io.boson.bsonPath.Interpreter;
 import io.boson.bsonPath.Program;
 import io.boson.bsonPath.TinyLanguage;
 import io.boson.nettybson.NettyBson;
-import io.netty.buffer.ByteBuf;
 import scala.Function1;
 import scala.Option;
 import scala.util.parsing.combinator.Parsers;
@@ -16,43 +15,23 @@ import io.boson.bsonValue.*;
 public class JavaInterface {
 
     public NettyBson createNettyBson(byte[] byteArray) {
-        Option<io.netty.buffer.ByteBuf> op = Option.apply(null);
-        Option<java.nio.ByteBuffer> op1 = Option.apply(null);
-        Option<io.vertx.core.buffer.Buffer> op2 = Option.apply(null);
-        Option<scala.collection.mutable.ArrayBuffer<java.lang.Object>> op3 = Option.apply(null);
-        return new NettyBson(Option.apply(byteArray), op, op1, op2, op3);
-    }
-
-    public NettyBson createNettyBson(ByteBuf byteBuf) {
-        Option<byte[]> op = Option.apply(null);
-        Option<java.nio.ByteBuffer> op1 = Option.apply(null);
-        Option<io.vertx.core.buffer.Buffer> op2 = Option.apply(null);
-        Option<scala.collection.mutable.ArrayBuffer<java.lang.Object>> op3 = Option.apply(null);
-        return new NettyBson(op, Option.apply(byteBuf), op1, op2, op3);
+        return new NettyBson(
+                Option.apply(byteArray),
+                Option.apply(null),
+                Option.apply(null),
+                Option.apply(null),
+                Option.apply(null)
+        );
     }
 
     public NettyBson createNettyBson(ByteBuffer byteBuffer) {
-        Option<byte[]> op = Option.apply(null);
-        Option<io.netty.buffer.ByteBuf> op1 = Option.apply(null);
-        Option<io.vertx.core.buffer.Buffer> op2 = Option.apply(null);
-        Option<scala.collection.mutable.ArrayBuffer<java.lang.Object>> op3 = Option.apply(null);
-        return new NettyBson(op, op1, Option.apply(byteBuffer), op2, op3);
-    }
-
-    public NettyBson createNettyBson(io.vertx.core.buffer.Buffer vertxBuffer) {
-        Option<byte[]> op = Option.apply(null);
-        Option<io.netty.buffer.ByteBuf> op1 = Option.apply(null);
-        Option<java.nio.ByteBuffer> op2 = Option.apply(null);
-        Option<scala.collection.mutable.ArrayBuffer<java.lang.Object>> op3 = Option.apply(null);
-        return new NettyBson(op, op1, op2, Option.apply(vertxBuffer), op3);
-    }
-
-    public NettyBson createNettyBson(scala.collection.mutable.ArrayBuffer<java.lang.Object> arrayBuffer) {
-        Option<byte[]> op = Option.apply(null);
-        Option<io.netty.buffer.ByteBuf> op1 = Option.apply(null);
-        Option<java.nio.ByteBuffer> op2 = Option.apply(null);
-        Option<io.vertx.core.buffer.Buffer> op3 = Option.apply(null);
-        return new NettyBson(op, op1, op2, op3, Option.apply(arrayBuffer));
+        return new NettyBson(
+                Option.apply(null),
+                Option.apply(null),
+                Option.apply(byteBuffer),
+                Option.apply(null),
+                Option.apply(null)
+        );
     }
 
     private Function1<String, BsValue> writer = (str) -> BsException$.MODULE$.apply(str);

--- a/src/main/java/io/boson/javaInterface/JavaInterface.java
+++ b/src/main/java/io/boson/javaInterface/JavaInterface.java
@@ -18,8 +18,6 @@ public class JavaInterface {
         return new NettyBson(
                 Option.apply(byteArray),
                 Option.apply(null),
-                Option.apply(null),
-                Option.apply(null),
                 Option.apply(null)
         );
     }
@@ -27,9 +25,7 @@ public class JavaInterface {
     public NettyBson createNettyBson(ByteBuffer byteBuffer) {
         return new NettyBson(
                 Option.apply(null),
-                Option.apply(null),
                 Option.apply(byteBuffer),
-                Option.apply(null),
                 Option.apply(null)
         );
     }

--- a/src/main/scala/io/boson/bsonPath/TinyLanguageTest.scala
+++ b/src/main/scala/io/boson/bsonPath/TinyLanguageTest.scala
@@ -51,7 +51,7 @@ object TinyLanguageTest {
 
 
       val arrTest: BsonArray = new BsonArray().add(2.2).add(2.4).add(2.6)
-      val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+      val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
       val key: String = "José"
       val language: String = "[0 to end] size"
       val parser = new TinyLanguage

--- a/src/main/scala/io/boson/nettybson/NettyBson.scala
+++ b/src/main/scala/io/boson/nettybson/NettyBson.scala
@@ -18,8 +18,10 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
   * This class encapsulates one Netty ByteBuf
   *
   */
-class NettyBson(byteArray: Option[Array[Byte]] = None, byteBuf: Option[ByteBuf] = None, javaByteBuf: Option[ByteBuffer] = None,
-                vertxBuff: Option[Buffer] = None, scalaArrayBuf: Option[ArrayBuffer[Byte]] = None) {
+class NettyBson( byteArray: Option[Array[Byte]] = None,
+                 javaByteBuf: Option[ByteBuffer] = None,
+                 scalaArrayBuf: Option[ArrayBuffer[Byte]] = None
+               ) {
 
   /*private val valueOfArgument: String = this match {
     case _ if javaByteBuf.isDefined => javaByteBuf.get.getClass.getSimpleName
@@ -35,21 +37,11 @@ class NettyBson(byteArray: Option[Array[Byte]] = None, byteBuf: Option[ByteBuf] 
       javaByteBuf.get.getClass.getSimpleName
     } else if(byteArray.isDefined) {
       byteArray.get.getClass.getSimpleName
-    } else if(byteBuf.isDefined) {
-      byteBuf.get.getClass.getSimpleName
-    } else if(vertxBuff.isDefined) {
-      vertxBuff.get.getClass.getSimpleName
     } else if(scalaArrayBuf.isDefined) {
       scalaArrayBuf.get.getClass.getSimpleName
     } else EMPTY_CONSTRUCTOR
 
   private val nettyBuffer: ByteBuf = valueOfArgument match {
-    case NETTY_READONLY_BUF => // Netty
-      val b = Unpooled.buffer()
-      b.writeBytes(byteBuf.get)
-    case NETTY_DEFAULT_BUF => // Netty
-      val b = Unpooled.buffer()
-      b.writeBytes(byteBuf.get)
     case ARRAY_BYTE => // Array[Byte]
       val b = Unpooled.buffer()
       b.writeBytes(byteArray.get)
@@ -59,15 +51,9 @@ class NettyBson(byteArray: Option[Array[Byte]] = None, byteBuf: Option[ByteBuf] 
       b.writeBytes(javaByteBuf.get)
       javaByteBuf.get.clear()
       b
-    case VERTX_BUF => // Vertx Buffer
-      val b = Unpooled.buffer()
-      b.writeBytes(vertxBuff.get.getBytes)
     case SCALA_ARRAYBUF => // Scala ArrayBuffer[Byte]
       val b = Unpooled.buffer()
       b.writeBytes(scalaArrayBuf.get.toArray)
-    case NETTY_DUPLICATED_BUF => // Netty
-      val b = Unpooled.buffer()
-      b.writeBytes(byteBuf.get)
     case EMPTY_CONSTRUCTOR =>
       Unpooled.buffer()
   }
@@ -547,7 +533,7 @@ class NettyBson(byteArray: Option[Array[Byte]] = None, byteBuf: Option[ByteBuf] 
   }
 
   def asReadOnly: NettyBson = {
-    new NettyBson(byteBuf = Option(nettyBuffer.asReadOnly()))
+    new NettyBson(byteArray = Option(nettyBuffer.asReadOnly().array()))
   }
 
   def isReadOnly: Boolean = {
@@ -628,7 +614,7 @@ class NettyBson(byteArray: Option[Array[Byte]] = None, byteBuf: Option[ByteBuf] 
   def readBytes(length: Int): NettyBson = {
       val bB: ByteBuf = Unpooled.buffer()
       nettyBuffer.readBytes(bB, length)
-      new NettyBson(byteBuf = Option(bB))
+      new NettyBson(byteArray = Option(bB.array()))
   }
 
   def readChar: Char = {

--- a/src/main/scala/io/boson/nettybson/NettyBson.scala
+++ b/src/main/scala/io/boson/nettybson/NettyBson.scala
@@ -2,11 +2,10 @@ package io.boson.nettybson
 
 
 import java.nio.{ByteBuffer, ReadOnlyBufferException}
-import java.nio.charset.{Charset, UnsupportedCharsetException}
+import java.nio.charset.Charset
 import io.boson.bson.{BsonArray, BsonObject}
 import io.netty.buffer.{ByteBuf, Unpooled}
 import io.boson.nettybson.Constants._
-import io.vertx.core.buffer.Buffer
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 

--- a/src/main/scala/io/boson/scalaInterface/ScalaInterface.scala
+++ b/src/main/scala/io/boson/scalaInterface/ScalaInterface.scala
@@ -1,10 +1,7 @@
 package io.boson.scalaInterface
 
-import java.nio.ByteBuffer
 import io.boson.bsonPath.{Interpreter, Program, TinyLanguage}
 import io.boson.nettybson.NettyBson
-import io.netty.buffer.ByteBuf
-import io.vertx.core.buffer.Buffer
 import scala.collection.mutable.ArrayBuffer
 import io.boson.bsonValue
 
@@ -15,15 +12,6 @@ class ScalaInterface {
 
   def createNettyBson(byteArray: Array[Byte]):NettyBson = {
      new NettyBson(byteArray = Option(byteArray))
-  }
-  def createNettyBson(byteBuf: ByteBuf):NettyBson = {
-    new NettyBson(byteBuf = Option(byteBuf))
-  }
-  def createNettyBson(byteBuffer: ByteBuffer):NettyBson = {
-    new NettyBson(javaByteBuf = Option(byteBuffer))
-  }
-  def createNettyBson(vertxBuffer: Buffer):NettyBson = {
-    new NettyBson(vertxBuff = Option(vertxBuffer))
   }
   def createNettyBson(arrayBuffer: ArrayBuffer[Byte]):NettyBson = {
     new NettyBson(scalaArrayBuf = Option(arrayBuffer))

--- a/src/test/scala/io/boson/BuffersTest.scala
+++ b/src/test/scala/io/boson/BuffersTest.scala
@@ -17,7 +17,7 @@ import scala.collection.mutable.ArrayBuffer
 @RunWith(classOf[JUnitRunner])
 class BuffersTest extends FunSuite {
   val bsonEvent: BsonObject = new BsonObject().put("kitchen", "dirty".getBytes).put("Grade", 'C').put("CharSequence", "It WORKS!!!")
-  val exampleNetty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+  val exampleNetty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
 
   test("Java ByteBuffer"){
     val javaBuffer: ByteBuffer = ByteBuffer.allocate(256)
@@ -26,14 +26,6 @@ class BuffersTest extends FunSuite {
     val nettyFromJava = new NettyBson(javaByteBuf = Option(javaBuffer))
     assert(new String(javaBuffer.array()) === new String(nettyFromJava.getByteBuf.array())
       , "Content from ByteBuffer(java) it's different from nettyFromJava")
-  }
-
-  test("Vertx ByteBuffer"){
-    val vertxBuf: Buffer = Buffer.buffer()
-    vertxBuf.appendBytes(exampleNetty.array)
-    val nettyFromVertx = new NettyBson(vertxBuff = Option(vertxBuf))
-    assert(new String(vertxBuf.getBytes) === new String(nettyFromVertx.getByteBuf.array())
-      , "Content from ByteBuffer(Vertx) it's different from nettyFromVertx")
   }
 
   test("Scala ArrayBuffer[Byte]"){

--- a/src/test/scala/io/boson/ExtractorTests.scala
+++ b/src/test/scala/io/boson/ExtractorTests.scala
@@ -30,35 +30,35 @@ class ExtractorTests extends FunSuite {
 
   test("Extract Int") {
     val bsonEvent: BsonObject = new BsonObject().put("StartUp", arr)
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     assert(1500 === nettyBson.extract(nettyBson.getByteBuf, "Américo", "first").get.asInstanceOf[List[Any]].head)
   }
 
   test("Extract Long") {
     val bsonEvent: BsonObject = new BsonObject().put("StartUp", arr)
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     assert(1250L === nettyBson.extract(nettyBson.getByteBuf, "Pedro", "first").get.asInstanceOf[List[Any]].head)
   }
 
   test("Extract Boolean") {
     val bsonEvent: BsonObject = new BsonObject().put("StartUp", arr)
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes()))
     assert(false === nettyBson.extract(nettyBson.getByteBuf, "José", "first").get.asInstanceOf[List[Any]].head)
   }
 
   test("Extract Null") {
     val bsonEvent: BsonObject = new BsonObject().put("StartUp", arr)
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes()))
     assert("Null" === nettyBson.extract(nettyBson.getByteBuf, "Amadeu", "first").get.asInstanceOf[List[Any]].head)
   }
 
   test("Extract Instant") {
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(globalObj.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(globalObj.encode().getBytes()))
     assertEquals(now.toString, new String(nettyBson.extract(nettyBson.getByteBuf, "UpdatedOn", "first").get.asInstanceOf[List[Any]].head.asInstanceOf[Array[Byte]]).replaceAll("\\p{C}", ""))
   }
 
   test("Extract String") {
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(globalObj.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(globalObj.encode().getBytes))
     assertEquals("Lisboa", new String(nettyBson.extract(nettyBson.getByteBuf, "Residence", "first")
       .get.asInstanceOf[List[Any]].head.asInstanceOf[Array[Byte]]).replaceAll("\\p{C}", ""))
   }
@@ -67,7 +67,7 @@ class ExtractorTests extends FunSuite {
     val help: ByteBuf = Unpooled.buffer()
     val finalBuf: ByteBuf = Unpooled.buffer()
 
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(globalObj.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(globalObj.encode().getBytes()))
 
     help.writeBytes(nettyBson.extract(nettyBson.getByteBuf, "FavoriteSentence", "first").get.asInstanceOf[List[Any]].head.asInstanceOf[Array[Byte]])
     finalBuf.writeBytes(io.netty.handler.codec.base64.Base64.decode(help))
@@ -75,7 +75,7 @@ class ExtractorTests extends FunSuite {
   }
 
   test("Extract Array[Byte] w/ String") {
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(globalObj.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(globalObj.encode().getBytes))
     assert("Be the best".getBytes === new String(java.util.Base64.getMimeDecoder
       .decode(new String(nettyBson.extract(nettyBson.getByteBuf, "FavoriteSentence", "first")
         .get.asInstanceOf[List[Any]].head.asInstanceOf[Array[Byte]]))).getBytes)
@@ -83,12 +83,12 @@ class ExtractorTests extends FunSuite {
 
   test("Extract BsonObject") {
     val bsonEvent: BsonObject = new BsonObject().put("First", obj1).put("Second", obj2).put("Third", obj3)
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes()))
     assert(obj2 === nettyBson.extract(nettyBson.getByteBuf, "Second", "first").get.asInstanceOf[List[Any]].head)
   }
 
   test("Extract BsonArray") {
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(globalObj.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(globalObj.encode().getBytes()))
     assert(arr === nettyBson.extract(nettyBson.getByteBuf, "Colleagues", "first").get.asInstanceOf[List[Any]].head)
   }
 
@@ -96,12 +96,12 @@ class ExtractorTests extends FunSuite {
     val bsonEvent: BsonObject = new BsonObject().put("StartUp", arr)
     val arr2: BsonArray = new BsonArray().add("Day3").add("Day20").add("Day31")
     obj2.put("JoséMonthLeave", arr2)
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes()))
     assert(arr2 === nettyBson.extract(nettyBson.getByteBuf, "JoséMonthLeave", "first").get.asInstanceOf[List[Any]].head)
   }
 
   test("Extract nonexistent key") {
-    val nettyBson: NettyBson = new NettyBson(vertxBuff = Option(globalObj.encode()))
+    val nettyBson: NettyBson = new NettyBson(byteArray = Option(globalObj.encode().getBytes()))
     assert(None === nettyBson.extract(nettyBson.getByteBuf, "Random", "first"))
   }
 }

--- a/src/test/scala/io/boson/HorribleTests.scala
+++ b/src/test/scala/io/boson/HorribleTests.scala
@@ -50,7 +50,7 @@ class HorribleTests extends FunSuite {
   test("Empty ObjEvent") {
     val key: String = "tempReadings"
     val expression: String = "first"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(obj1.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(obj1.encode().getBytes))
     val resultParser = callParse(netty, key, expression)
     assert(BsSeq(Seq()) === resultParser)
   }
@@ -58,7 +58,7 @@ class HorribleTests extends FunSuite {
   test("Empty ArrEvent") {
     val key: String = "tempReadings"
     val expression: String = "first"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr1.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr1.encode().getBytes))
     val resultParser = callParse(netty, key, expression)
     assert(BsSeq(Seq()) === resultParser)
   }
@@ -74,7 +74,7 @@ class HorribleTests extends FunSuite {
   test("Bad parser expression V1") {
     val key: String = "tempReadings"
     val expression: String = "Something Wrong [2 to 3]"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr1.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr1.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Failure parsing!") === result)
   }
@@ -82,7 +82,7 @@ class HorribleTests extends FunSuite {
   test("Bad parser expression V2") {
     val key: String = ""
     val expression: String = "[0 to 1] kunhnfvgklhu "
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Failure parsing!") === result)
   }
@@ -90,7 +90,7 @@ class HorribleTests extends FunSuite {
   test("Bad parser expression V3") {
     val key: String = ""
     val expression: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Failure parsing!") === result)
   }
@@ -98,7 +98,7 @@ class HorribleTests extends FunSuite {
   test("Bad parser expression V4") {
     val key: String = ""
     val expression: String = "[1 xx 2]"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Failure parsing!") === result)
   }
@@ -106,7 +106,7 @@ class HorribleTests extends FunSuite {
   test("Bad parser expression V5") {
     val key: String = ""
     val expression: String = "first ?= 4.0 "
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Failure parsing!") === result)
   }
@@ -114,7 +114,7 @@ class HorribleTests extends FunSuite {
   test("IndexOutOfBounds") {
     val key: String = ""
     val expression: String = "[2 to 3]"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val resultParser = callParse(netty, key, expression)
     assert(BsSeq(Seq()) === resultParser)
   }
@@ -122,7 +122,7 @@ class HorribleTests extends FunSuite {
   test("Extract array when doesn't exists V1") {
     val key: String = "tempReadings"
     val expression: String = "[2 until 3]"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser = callParse(netty, key, expression)
     assert(BsSeq(Seq()) === resultParser)
   }
@@ -130,7 +130,7 @@ class HorribleTests extends FunSuite {
   test("Extract array when doesn't exists V2") {
     val key: String = ""
     val expression: String = "[2 until 3]"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser = callParse(netty, key, expression)
     assert(BsSeq(Seq()) === resultParser)
   }
@@ -138,7 +138,7 @@ class HorribleTests extends FunSuite {
   test("Extract value with wrong Key") {
     val key: String = "tempReadingS"
     val expression: String = "first"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser = callParse(netty, key, expression)
     assert(BsSeq(Seq()) === resultParser)
   }
@@ -146,7 +146,7 @@ class HorribleTests extends FunSuite {
   test("Extract value when only exists BsonArray") {
     val key: String = "tempReadingS"
     val expression: String = "first"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val resultParser = callParse(netty, key, expression)
     assert(BsSeq(Seq()) === resultParser)
   }
@@ -154,7 +154,7 @@ class HorribleTests extends FunSuite {
   test("Check if key exists when key is empty") {
     val key: String = ""
     val expression: String = "in"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Expressions in/Nin aren't available with Empty Key") === result)
   }
@@ -162,7 +162,7 @@ class HorribleTests extends FunSuite {
   test("Check if key  doesn't exists when key is empty") {
     val key: String = ""
     val expression: String = "Nin"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Expressions in/Nin aren't available with Empty Key") === result)
   }
@@ -170,7 +170,7 @@ class HorribleTests extends FunSuite {
   test("Mixing in/Nin with other expressions") {
     val key: String = ""
     val expression: String = "all > 5 Nin"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Failure parsing!") === result)
   }
@@ -178,7 +178,7 @@ class HorribleTests extends FunSuite {
   test("Mixing size/isEmpty with other expressions") {
     val key: String = ""
     val expression: String = "all size Nin"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Failure parsing!") === result)
   }
@@ -186,7 +186,7 @@ class HorribleTests extends FunSuite {
   test("Only WhiteSpaces in Expression") {
     val key: String = ""
     val expression: String = "  "
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsException("Failure parsing!") === result)
   }
@@ -194,7 +194,7 @@ class HorribleTests extends FunSuite {
   test("array prob 1") {
     val key: String = "José"
     val expression: String = "   all    [     0    to   end      ]   size  "
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent1.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent1.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsSeq(Seq(3,1,1)) === result)
   }
@@ -202,7 +202,7 @@ class HorribleTests extends FunSuite {
   test("array prob 2") {
     val key: String = ""
     val expression: String = "   all    [     0    to   end      ]   size  "
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr11.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr11.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsNumber(4) === result)
   }
@@ -210,7 +210,7 @@ class HorribleTests extends FunSuite {
   test("array prob 3") {
     val key: String = ""
     val expression: String = "   first    [     0    to   end      ]   size  "
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arr11.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arr11.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsNumber(1) === result)
   }
@@ -218,7 +218,7 @@ class HorribleTests extends FunSuite {
   test("array prob 4") {
     val key: String = "José"
     val expression: String = "   first    [     0    to   end      ]   size  "
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent1.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent1.encode().getBytes))
     val result: BsValue = callParse(netty, key, expression)
     assert(BsSeq(Seq(3)) === result)
   }

--- a/src/test/scala/io/boson/LanguageTests.scala
+++ b/src/test/scala/io/boson/LanguageTests.scala
@@ -39,21 +39,21 @@ class LanguageTests extends FunSuite {
 
   test("First") {
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, "first")
     assert(BsSeq(List(arr)) === resultParser)
   }
 
   test("Last") {
     val key: String = "doorOpen"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, "last")
     assert(BsSeq(List(true)) === resultParser)
   }
 
   test("All") {
     val key: String = "fridgeTemp"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, "all")
     assert(BsSeq(List(5.2f, 5.0f, 3.854f)) === resultParser)
   }
@@ -61,7 +61,7 @@ class LanguageTests extends FunSuite {
   test("First [# until #]") {
     val expression: String = "first [0 until 2]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(0))
       .add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1)))) === resultParser)
@@ -70,7 +70,7 @@ class LanguageTests extends FunSuite {
   test("Last [# until #]") {
     val expression: String = "last [0 until 2]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(0))
       .add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1)))) === resultParser)
@@ -79,7 +79,7 @@ class LanguageTests extends FunSuite {
   test("First [# to #]") {
     val expression: String = "first [1 to 2]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1))
       .add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(2)))) === resultParser)
@@ -88,7 +88,7 @@ class LanguageTests extends FunSuite {
   test("Last [# to #]") {
     val expression: String = "last [0 to 2]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(0))
       .add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1))
@@ -98,7 +98,7 @@ class LanguageTests extends FunSuite {
   test("First [# .. end]") {
     val expression: String = "first [0 until end]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(0))
       .add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1)))) === resultParser)
@@ -107,7 +107,7 @@ class LanguageTests extends FunSuite {
   test("Last [# .. end]") {
     val expression: String = "last [0 to end]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(0))
       .add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1))
@@ -117,7 +117,7 @@ class LanguageTests extends FunSuite {
   test("[# .. end]") {
     val expression: String = "[1 until end]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray()
       .add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1)))) === resultParser)
@@ -126,7 +126,7 @@ class LanguageTests extends FunSuite {
   test("[# to #]") {
     val expression: String = "[1 to 1]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1)))) === resultParser)
   }
@@ -134,7 +134,7 @@ class LanguageTests extends FunSuite {
   test("[# until #]") {
     val expression: String = "[1 until 2]"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(bsonEvent.getBsonArray("fridgeReadings").getBsonObject(1)))) === resultParser)
   }
@@ -142,7 +142,7 @@ class LanguageTests extends FunSuite {
   test("In") {
     val expression: String = "in"
     val key: String = "fridgeTemp"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsBoolean(true) === resultParser)
   }
@@ -150,7 +150,7 @@ class LanguageTests extends FunSuite {
   test("Nin") {
     val expression: String = "Nin"
     val key: String = "fridgeTemp"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsBoolean(false) === resultParser)
   }
@@ -158,7 +158,7 @@ class LanguageTests extends FunSuite {
   test("(all|first|last) size") {
     val expression: String = "all size"
     val key: String = "fanVelocity"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsNumber(4) === resultParser)
   }
@@ -166,7 +166,7 @@ class LanguageTests extends FunSuite {
   test("(all|first|last) isEmpty") {
     val expression: String = "first isEmpty"
     val key: String = "fanVelocity"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsBoolean(false) === resultParser)
   }
@@ -174,7 +174,7 @@ class LanguageTests extends FunSuite {
   test("[# .. #] size") {
     val expression: String = "[1 to 2] size"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(2)) === resultParser)
   }
@@ -182,7 +182,7 @@ class LanguageTests extends FunSuite {
   test("[# .. #] isEmpty") {
     val expression: String = "[1 until end] isEmpty"
     val key: String = "fridgeTemp"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsBoolean(true) === resultParser)
   }
@@ -190,7 +190,7 @@ class LanguageTests extends FunSuite {
   test("(all|first|last) [# .. #] size") {
     val expression: String = "all [0 to 1] size"
     val key: String = "fridgeReadings"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(Seq(2)) === resultParser)
   }
@@ -198,14 +198,14 @@ class LanguageTests extends FunSuite {
   test("(all|first|last) [# .. #] isEmpty") {
     val expression: String = "first [0 to 1] isEmpty"
     val key: String = "doorOpen"
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsBoolean(true) === resultParser)
   }
 
   test("First w/key BobjRoot") {
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, "first")
     assert(BsSeq(List()) === resultParser)
   }
@@ -215,21 +215,21 @@ class LanguageTests extends FunSuite {
 
   test("First w/key BarrRoot") {
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, "first")
     assert(BsSeq(List(arr)) === resultParser)
   }
 
   test("Last w/key") {
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, "last")
     assert(BsSeq(List(arrEvent.getDouble(3))) === resultParser)
   }
 
   test("All w/key") {
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, "all")
     assert(BsSeq(List(arrEvent)) === resultParser)
   }
@@ -237,7 +237,7 @@ class LanguageTests extends FunSuite {
   test("First [# until #] w/key") {
     val expression: String = "first [0 until 2]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(Seq(arrEvent.getBsonArray(0))) === resultParser)
   }
@@ -245,7 +245,7 @@ class LanguageTests extends FunSuite {
   test("Last [# until #] w/key") {
     val expression: String = "last [0 until 2]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(Seq(arrEvent.getBsonObject(1))) === resultParser)
   }
@@ -253,7 +253,7 @@ class LanguageTests extends FunSuite {
   test("First [# to #] w/key") {
     val expression: String = "first [1 to 2]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(Seq(arrEvent.getBsonObject(1))) === resultParser)
   }
@@ -261,7 +261,7 @@ class LanguageTests extends FunSuite {
   test("Last [# to #] w/key") {
     val expression: String = "last [0 to 2]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(Seq(arrEvent.getString(2))) === resultParser)
   }
@@ -269,7 +269,7 @@ class LanguageTests extends FunSuite {
   test("First [# .. end] w/key") {
     val expression: String = "first [0 until end]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(Seq(arrEvent.getBsonArray(0))) === resultParser)
   }
@@ -277,7 +277,7 @@ class LanguageTests extends FunSuite {
   test("Last [# .. end] w/key") {
     val expression: String = "all [0 to end]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(arrEvent.getBsonArray(0))
       .add(arrEvent.getBsonObject(1))
@@ -288,7 +288,7 @@ class LanguageTests extends FunSuite {
   test("[# .. end] w/key") {
     val expression: String = "[1 until end]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(arrEvent.getBsonObject(1))
       .add(arrEvent.getString(2)))) === resultParser)
@@ -297,7 +297,7 @@ class LanguageTests extends FunSuite {
   test("[# to #] w/key") {
     val expression: String = "[1 to 1]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(arrEvent.getBsonObject(1)))) === resultParser)
   }
@@ -305,7 +305,7 @@ class LanguageTests extends FunSuite {
   test("[# until #] w/key") {
     val expression: String = "[1 until 2]"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(new BsonArray().add(arrEvent.getBsonObject(1)))) === resultParser)
   }
@@ -316,7 +316,7 @@ class LanguageTests extends FunSuite {
   test("(all|first|last) size w/key") {
     val expression: String = "all size"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsNumber(4) === resultParser)
   }
@@ -324,7 +324,7 @@ class LanguageTests extends FunSuite {
   test("(all|first|last) isEmpty w/key") {
     val expression: String = "first isEmpty"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsBoolean(false) === resultParser)
   }
@@ -332,7 +332,7 @@ class LanguageTests extends FunSuite {
   test("[# .. #] size w/key") {
     val expression: String = "[1 to 2] size"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsSeq(List(2)) === resultParser)
   }
@@ -340,7 +340,7 @@ class LanguageTests extends FunSuite {
   test("[# .. #] isEmpty w/key") {
     val expression: String = "[1 until end] isEmpty"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsBoolean(false) === resultParser)
   }
@@ -348,7 +348,7 @@ class LanguageTests extends FunSuite {
   test("(all|first|last) [# .. #] size w/key") {
     val expression: String = "all [0 to 1] size"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(arrEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsNumber(2) === resultParser)
   }
@@ -356,7 +356,7 @@ class LanguageTests extends FunSuite {
   test("(all|first|last) [# .. #] isEmpty w/key") {
     val expression: String = "first [0 to 1] isEmpty"
     val key: String = ""
-    val netty: NettyBson = new NettyBson(vertxBuff = Option(bsonEvent.encode()))
+    val netty: NettyBson = new NettyBson(byteArray = Option(bsonEvent.encode().getBytes))
     val resultParser: BsValue = callParse(netty, key, expression)
     assert(BsBoolean(true) === resultParser)
   }

--- a/src/test/scala/io/boson/ScalaInterfaceTests.scala
+++ b/src/test/scala/io/boson/ScalaInterfaceTests.scala
@@ -21,7 +21,7 @@ import org.scalatest.junit.JUnitRunner
     test("extractSeqWithScalaInterface") {
       val key: String = ""
       val language: String = "first"
-      val netty: NettyBson = sI.createNettyBson(ba1.encode())
+      val netty: NettyBson = sI.createNettyBson(ba1.encode().getBytes)
       val result: BsValue = sI.parse(netty, key, language)
 
       assert(BsSeq(Seq("ArrayField")) === result)
@@ -30,7 +30,7 @@ import org.scalatest.junit.JUnitRunner
     test("extractIntWithScalaInterface") {
       val key: String = ""
       val language: String = "[5 until 6] size"
-      val netty: NettyBson = sI.createNettyBson(ba1.encode())
+      val netty: NettyBson = sI.createNettyBson(ba1.encode().getBytes)
       val result: BsValue = sI.parse(netty, key, language)
 
       assert(BsNumber(BigDecimal(0)) === result)
@@ -39,7 +39,7 @@ import org.scalatest.junit.JUnitRunner
     test("extractBoolWithScalaInterface") {
       val key: String = ""
       val language: String = "[5 to end] isEmpty"
-      val netty: NettyBson = sI.createNettyBson(ba1.encode())
+      val netty: NettyBson = sI.createNettyBson(ba1.encode().getBytes)
       val result: BsValue = sI.parse(netty, key, language)
 
       assert(BsBoolean(true) === result)
@@ -48,7 +48,7 @@ import org.scalatest.junit.JUnitRunner
     test("extractExceptionWithScalaInterface") {
       val key: String = "field1"
       val language: String = "last [0 until end] in"
-      val netty: NettyBson = sI.createNettyBson(ba1.encode())
+      val netty: NettyBson = sI.createNettyBson(ba1.encode().getBytes)
       val result: BsValue = sI.parse(netty, key, language)
 
       assert(BsException("`isEmpty' expected but `i' found") === result)


### PR DESCRIPTION
Regarding issue #2 eliminated all external dependencies from both interfaces.
NettyBson constructor no longer has the arguments of vertx and netty buffers.
Fixed corresponding tests