### PR TITLE
Injector type consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - language: scala
       scala: 2.12.3
-      script: sbt clean "test-only *BuffersTest *ExtractorTests *HorribleTests *LanguageTests *LongInputTests *ScalaInterfaceTests *InjectorsTest"
+      script: sbt clean "test-only *BuffersTest *ExtractorTests *HorribleTests *LanguageTests *LongInputTests *ScalaInterfaceTests *InjectorsTest *TypeConsistencyTests"
 
 
     - language: java

--- a/src/main/scala/io/boson/injectors/Injector.scala
+++ b/src/main/scala/io/boson/injectors/Injector.scala
@@ -205,7 +205,12 @@ class Injector {
             (newBuffer.writeDoubleLE(n), 0)
           case n: Double =>
             (newBuffer.writeDoubleLE(n), 0)
-          case _ => throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_FLOAT_DOUBLE") //  [IT,OT] => IT != OT
+          case _ =>
+            if(value == null){
+              throw CustomException(s"Wrong inject type. Injecting type NULL. Value type require D_FLOAT_DOUBLE") //  [IT,OT] => IT != OT
+            }else{
+              throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_FLOAT_DOUBLE") //  [IT,OT] => IT != OT
+            }
         }
       case D_ARRAYB_INST_STR_ENUM_CHRSEQ =>
         val length: Int = buffer.readIntLE()
@@ -220,7 +225,12 @@ class Injector {
           case n: Instant =>
             val aux: Array[Byte] = n.toString.getBytes()
             (newBuffer.writeIntLE(aux.length + 1).writeBytes(aux).writeByte(0), (aux.length + 1) - length)
-          case _ => throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ") //  [IT,OT] => IT != OT
+          case _ =>
+            if(value == null){
+              throw CustomException(s"Wrong inject type. Injecting type NULL. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ") //  [IT,OT] => IT != OT
+            }else{
+              throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ") //  [IT,OT] => IT != OT
+            }
         }
       case D_BSONOBJECT =>
         val valueLength: Int = buffer.readIntLE() //  length of current obj
@@ -234,7 +244,12 @@ class Injector {
             val buf: Array[Byte] = Mapper.encode(bsonObject2)
             (newBuffer.writeBytes(buf), buf.length - valueLength)
           case _ =>
-            throw CustomException(s"Wrong inject type. Injecting type ${newValue.getClass.getSimpleName}. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])")
+            if(newValue == null){
+              throw CustomException(s"Wrong inject type. Injecting type NULL. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])")
+            }else{
+              throw CustomException(s"Wrong inject type. Injecting type ${newValue.getClass.getSimpleName}. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])")
+            }
+
         }
       case D_BSONARRAY =>
         val valueLength: Int = buffer.readIntLE()
@@ -248,7 +263,12 @@ class Injector {
             val arr: Array[Byte] = Mapper.encode(bsonArray2)
             (newBuffer.writeBytes(arr), arr.length - valueLength) //  ZERO  for now, cant be zero
           case _ =>
-            throw CustomException(s"Wrong inject type. Injecting type ${newValue.getClass.getSimpleName}. Value type require D_BSONARRAY (java List or scala Array)")
+            if(newValue == null){
+              throw CustomException(s"Wrong inject type. Injecting type NULL. Value type require D_BSONARRAY (java List or scala Array)")
+            }else{
+              throw CustomException(s"Wrong inject type. Injecting type ${newValue.getClass.getSimpleName}. Value type require D_BSONARRAY (java List or scala Array)")
+            }
+
         }
       case D_BOOLEAN =>
         val value: Any = f(buffer.readBoolean())
@@ -256,7 +276,11 @@ class Injector {
           case bool: Boolean =>
             (newBuffer.writeBoolean(bool), 0)
           case _ =>
-            throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_BOOLEAN")
+            if(value == null){
+              throw CustomException(s"Wrong inject type. Injecting type NULL. Value type require D_BOOLEAN")
+            }else{
+              throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_BOOLEAN")
+            }
         }
       case D_NULL => (newBuffer, 0) //  returns empty buffer
       case D_INT =>
@@ -265,7 +289,11 @@ class Injector {
           case n: Int =>
             (newBuffer.writeIntLE(n), 0)
           case _ =>
-            throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_INT")
+            if(value == null){
+              throw CustomException(s"Wrong inject type. Injecting type NULL. Value type require D_INT")
+            }else{
+              throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_INT")
+            }
         }
       case D_LONG =>
         val value: Any = f(buffer.readLongLE())
@@ -273,7 +301,11 @@ class Injector {
           case n: Long =>
             (newBuffer.writeLongLE(n), 0)
           case _ =>
-            throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_LONG")
+            if(value == null){
+              throw CustomException(s"Wrong inject type. Injecting type NULL. Value type require D_LONG")
+            }else{
+              throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_LONG")
+            }
         }
     }
   }

--- a/src/main/scala/io/boson/injectors/Injector.scala
+++ b/src/main/scala/io/boson/injectors/Injector.scala
@@ -19,274 +19,6 @@ import scala.collection.mutable.ListBuffer
   * Created by Ricardo Martins on 07/11/2017.
   */
 
-
-//object e extends Enumeration {
-//  val A: e.Value = Value("Asdghrt")
-//  val B: e.Value = Value("Bdysrtyry")
-//}
-//
-//object Injector extends App {
-//
-//  val bytearray1: Array[Byte] = "AlguresPorAi".getBytes()
-//  val bytearray2: Array[Byte] = "4".getBytes()
-//  val float: Float = 11.toFloat
-//  val newFloat: Float = 15.toFloat
-//  val bObj: BsonObject = new BsonObject().put("bsonObj", "ola")
-//  val newbObj: BsonObject = new BsonObject().put("newbsonObj", "newbsonObj")
-//  val bool: Boolean = true
-//  val newBool: Boolean = false
-//  val long: Long = 100000001.toLong
-//  val newLong: Long = 200000002.toLong
-//  val bsonArray: BsonArray = new BsonArray().add(new BsonObject().put("field", "1")).add(new BsonObject().put("hg", 2)).add(new BsonObject().put("field", "2"))
-//  //.add(1).add(2).add("Hi")
-//  val newbsonArray: BsonArray = new BsonArray().add(3).add(4).add("Bye")
-//  val enumJava = io.boson.injectors.EnumerationTest.A
-//  val newEnumJava = io.boson.injectors.EnumerationTest.B
-//  val charseq: CharSequence = "charSequence"
-//  val anotherCharseq: CharSequence = "AnothercharSequence"
-//  val inj: Injector = new Injector
-//  val ext = new ScalaInterface
-//  val ins: Instant = Instant.now()
-//  val ins1: Instant = Instant.now()
-//  //val obj1: BsonObject = new BsonObject().put("bsonArray", bsonArray).putNull("null").put("enum", e.A.toString)//.put("field", 0).put("bool", bool).put("long", long).put("no", "ok").put("float", float).put("bObj",bObj).put("charS", charseq).put("array", bytearray1).put("inst", ins)
-//
-//  val obj1: BsonObject = new BsonObject().put("fridgeTemp", 5.2f).put("fanVelocity", 20.5).put("doorOpen", false)
-//  val obj2: BsonObject = new BsonObject().put("fridgeTemp", 5.0f).put("fanVelocity", 20.6).put("doorOpen", false)
-//  val obj3: BsonObject = new BsonObject().put("fridgeTemp", 3.854f).put("fanVelocity", 20.5).put("doorOpen", true)
-//  val arr: BsonArray = new BsonArray().add(obj1).add(obj2).add(obj3)
-//  val bsonEvent: BsonObject = new BsonObject().put("fridgeReadings", arr)
-//
-//  val obj: BsonArray = bsonArray
-//  val netty: Option[Boson] = Some(new Boson(byteArray = Option(bsonEvent.encode().getBytes)))
-//
-//  println(bsonEvent)
-//  println(bsonEvent.encode())
-//
-//  val bufferedSource: Source = Source.fromURL(getClass.getResource("/jsonOutput.txt"))
-//  val finale: String = bufferedSource.getLines.toSeq.head
-//  bufferedSource.close
-//  val json: JsonObject = new JsonObject(finale)
-//  val bson: BsonObject = new BsonObject(json)
-//  val boson: Option[Boson] = Some(ext.createBoson(bson.encode().getBytes))
-//
-//  val s: Any = ext.parse(boson.get, "Tags", "first")
-//  println("Extracting first \"Tags\" ->" + s)
-//  println("-----------------------------------------------------------------------------------------------------------------------------------------------------------------------")
-//
-//  val b1: Try[Boson] = Try(inj.modify(boson, "Tags", _ => new BsonObject()).get)
-//
-//  println("-----------------------------------------------------------------------------------------------------------------------------------------------------------------------")
-//
-//
-//  b1 match {
-//    case Success(v) =>
-//      val s: Any = ext.parse(v, "Tags", "first")
-//      //println(s.getClass.getSimpleName)
-//      println("Extracting first \"Tags\" ->" + s)
-//    case Failure(e) => println(e.getStackTrace.foreach(p => println(p.toString)))
-//  }
-//}
-//
-//object ChangeStrInsideManyObj extends App {
-//
-//  val bP: ByteProcessor = (value: Byte) => {
-//    println("char= " + value.toChar + " int= " + value.toInt + " byte= " + value)
-//    true
-//  }
-//  val obj2: BsonObject = new BsonObject().put("Its", "Me!!!")
-//  val obj1: BsonObject = new BsonObject().put("Hi", obj2)
-//  val bsonEvent: BsonObject = new BsonObject().put("fridgeTemp", obj1)
-//  //.put("sec", 1)//.put("bool", true)
-//  val inj: Injector = new Injector
-//
-//  val netty: Option[Boson] = Some(new Boson(byteArray = Option(bsonEvent.encode().getBytes)))
-//
-//  println(bsonEvent)
-//  println(bsonEvent.encode())
-//
-//  netty.get.getByteBuf.forEachByte(bP)
-//  val b1: Try[Boson] = Try(inj.modify(netty, "Its", _ => "Y").get)
-//
-//  b1 match {
-//    case Success(v) =>
-//      v.getByteBuf.forEachByte(bP)
-//      val sI: ScalaInterface = new ScalaInterface
-//      println("Extracting the field injected with value: " + new String(sI.parse(v, "Its", "last").asInstanceOf[List[Array[Byte]]].head))
-//
-//    case Failure(e) =>
-//      println(e.getMessage)
-//      println(e.getStackTrace.foreach(p => println(p.toString)))
-//  }
-//
-//
-//}
-//
-//object changeObj extends App {
-//
-//  val bP: ByteProcessor = (value: Byte) => {
-//    println("char= " + value.toChar + " int= " + value.toInt + " byte= " + value)
-//    true
-//  }
-//  val obj1: BsonObject = new BsonObject().put("Hi", "Me!!!")
-//  val bsonEvent: BsonObject = new BsonObject().put("fridgeTemp", obj1)
-//  //.put("sec", 1)//.put("bool", true)
-//  val inj: Injector = new Injector
-//
-//  val netty: Option[Boson] = Some(new Boson(byteArray = Option(bsonEvent.encode().getBytes)))
-//
-//  println(bsonEvent)
-//  println(bsonEvent.encode())
-//
-//  netty.get.getByteBuf.forEachByte(bP)
-//  val obj2: BsonObject = new BsonObject().put("Hi", "0123456789")
-//  val b1: Try[Boson] = Try(inj.modify(netty, "fridgeTemp", _ => obj2).get)
-//
-//  b1 match {
-//    case Success(v) =>
-//      v.getByteBuf.forEachByte(bP)
-//      val sI: ScalaInterface = new ScalaInterface
-//      println("Extracting the field injected with value: " + sI.parse(v, "fridgeTemp", "last").asInstanceOf[List[BsonObject]].head)
-//
-//    case Failure(e) =>
-//      println(e.getMessage)
-//      println(e.getStackTrace.foreach(p => println(p.toString)))
-//  }
-//}
-//
-//object Testing1 extends App {
-//
-//  val bP: ByteProcessor = (value: Byte) => {
-//    println("char= " + value.toChar + " int= " + value.toInt + " byte= " + value)
-//    true
-//  }
-//  val obj2: BsonObject = new BsonObject().put("Its", "Me!!!")
-//  val obj1: BsonObject = new BsonObject().put("Hi", 10)
-//  val array1: BsonArray = new BsonArray().add(obj2).add("oi").add(2).add(obj2)
-//  val bsonEvent: BsonObject = new BsonObject().put("fridgeTemp", obj1)
-//  val inj: Injector = new Injector
-//
-//  val netty: Option[Boson] = Some(new Boson(byteArray = Option(array1.encode().getBytes)))
-//
-//  println(array1)
-//  println(array1.encode())
-//
-//  netty.get.getByteBuf.forEachByte(bP)
-//
-//  val b1: Try[Boson] = Try(inj.modify(netty, "Its", _ => "Y").get)
-//
-//  b1 match {
-//    case Success(v) =>
-//      v.getByteBuf.forEachByte(bP)
-//      val sI: ScalaInterface = new ScalaInterface
-//      println("Extracting the field injected with value: ")
-//      sI.parse(v, "Its", "all").asInstanceOf[List[Array[Byte]]].foreach(elem => println("-> " + new String(elem)))
-//
-//    case Failure(e) =>
-//      println(e.getMessage)
-//      println(e.getStackTrace.foreach(p => println(p.toString)))
-//  }
-//
-//
-//}
-//
-//object ObjAsRoot extends App {
-//
-//  val bP: ByteProcessor = (value: Byte) => {
-//    println("char= " + value.toChar + " int= " + value.toInt + " byte= " + value)
-//    true
-//  }
-//  val bsonEvent: BsonObject = new BsonObject().put("sec", 1).put("fridgeTemp", "Hi").put("bool", true)
-//  val inj: Injector = new Injector
-//
-//  val netty: Option[Boson] = Some(new Boson(byteArray = Option(bsonEvent.encode().getBytes)))
-//
-//  println(bsonEvent)
-//  println(bsonEvent.encode())
-//
-//  netty.get.getByteBuf.forEachByte(bP)
-//  val b1: Try[Boson] = Try(inj.modify(netty, "fridgeTemp", _ => "12345").get)
-//
-//  b1 match {
-//    case Success(v) =>
-//      v.getByteBuf.forEachByte(bP)
-//      val sI: ScalaInterface = new ScalaInterface
-//      println("Extracting the field injected with value: " + new String(sI.parse(v, "fridgeTemp", "all").asInstanceOf[List[Array[Byte]]].head))
-//
-//    case Failure(e) =>
-//      println(e.getMessage)
-//      println(e.getStackTrace.foreach(p => println(p.toString)))
-//  }
-//
-//
-//}
-//
-//object ArrInsideObj extends App {
-//
-//  val bP: ByteProcessor = (value: Byte) => {
-//    println("char= " + value.toChar + " int= " + value.toInt + " byte= " + value)
-//    true
-//  }
-//  val array1: BsonArray = new BsonArray().add(1).add(2)
-//  val bsonEvent: BsonObject = new BsonObject().put("sec", 1).put("fridgeTemp", array1).put("bool", "false!!!")
-//  val inj: Injector = new Injector
-//
-//  val netty: Option[Boson] = Some(new Boson(byteArray = Option(bsonEvent.encode().getBytes)))
-//
-//  println(bsonEvent)
-//  println(bsonEvent.encode())
-//
-//  netty.get.getByteBuf.forEachByte(bP)
-//  val b1: Try[Boson] = Try(inj.modify(netty, "bool", _ => "true").get)
-//
-//  b1 match {
-//    case Success(v) =>
-//      v.getByteBuf.forEachByte(bP)
-//      val sI: ScalaInterface = new ScalaInterface
-//      println("Extracting the field injected with value: " + new String(sI.parse(v, "bool", "all").asInstanceOf[List[Array[Byte]]].head))
-//
-//    case Failure(e) =>
-//      println(e.getMessage)
-//      println(e.getStackTrace.foreach(p => println(p.toString)))
-//  }
-//
-//
-//}
-//
-//object BsObjRootWithDeepMix extends App {
-//
-//  val bP: ByteProcessor = (value: Byte) => {
-//    println("char= " + value.toChar + " int= " + value.toInt + " byte= " + value)
-//    true
-//  }
-//  val obj3: BsonObject = new BsonObject().put("John", "NoBody")
-//  val obj2: BsonObject = new BsonObject().put("John", "Locke")
-//  val arr2: BsonArray = new BsonArray().add(obj2)
-//  val obj1: BsonObject = new BsonObject().put("hey", "me").put("will", arr2)
-//  val array1: BsonArray = new BsonArray().add(1).add(2).add(obj1)
-//  val bsonEvent: BsonObject = new BsonObject().put("sec", 1).put("fridgeTemp", array1).put("bool", "false!!!").put("finally", obj3)
-//  val inj: Injector = new Injector
-//
-//  val netty: Option[Boson] = Some(new Boson(byteArray = Option(bsonEvent.encode().getBytes)))
-//
-//  println(bsonEvent)
-//  println(bsonEvent.encode())
-//
-//  //netty.get.getByteBuf.forEachByte(bP)
-//  val b1: Try[Boson] = Try(inj.modify(netty, "John", _ => "SomeBody").get)
-//
-//  b1 match {
-//    case Success(v) =>
-//      //v.getByteBuf.forEachByte(bP)
-//      val sI: ScalaInterface = new ScalaInterface
-//      println("Extracting values of key \"John\" : ")
-//      sI.parse(v, "John", "all").asInstanceOf[List[Array[Byte]]].foreach(elem => println("-> " +new String(elem)))
-//    case Failure(e) =>
-//      println(e.getMessage)
-//      println(e.getStackTrace.foreach(p => println(p.toString)))
-//  }
-//
-//
-//}
 object Testing1 extends App {
 
   val bP: ByteProcessor = (value: Byte) => {
@@ -431,7 +163,7 @@ class Injector {
     key.toCharArray.deep == new String(fieldBytes.toArray).toCharArray.deep
   }
 
-  def matcher(buffer: ByteBuf, fieldID: String, indexOfFinish: Int, f: Any => Any): (Option[ByteBuf], Int) = {
+  private def matcher(buffer: ByteBuf, fieldID: String, indexOfFinish: Int, f: Any => Any): (Option[ByteBuf], Int) = {
     val startReaderIndex: Int = buffer.readerIndex()
     //    val totalSize = indexOfFinish - startReaderIndex
     println(s"matcher..............startReaderIndex: $startReaderIndex")
@@ -463,7 +195,7 @@ class Injector {
     }
   }
 
-  def modifier(buffer: ByteBuf, seqType: Int, f: Any => Any): (ByteBuf, Int) = {
+  private def modifier(buffer: ByteBuf, seqType: Int, f: Any => Any): (ByteBuf, Int) = {
     val newBuffer: ByteBuf = Unpooled.buffer() //  corresponds only to the new value
     seqType match {
       case D_FLOAT_DOUBLE =>
@@ -496,7 +228,7 @@ class Injector {
         }
       case D_BSONOBJECT =>
         val valueLength: Int = buffer.readIntLE() //  length of current obj
-      val bsonObject: ByteBuf = buffer.readBytes(valueLength - 4)
+        val bsonObject: ByteBuf = buffer.readBytes(valueLength - 4)
         val newValue: Any = f(bsonObject)
         newValue match {
           case bsonObject1: java.util.Map[_, _] =>
@@ -515,10 +247,10 @@ class Injector {
         newValue match {
           case bsonArray1: java.util.List[_] =>
             val arr: Array[Byte] = Mapper.encode(bsonArray1.asInstanceOf[java.util.List[_]])
-            (newBuffer.writeBytes(arr), 0) //  ZERO  for now, cant be zero
+            (newBuffer.writeBytes(arr), arr.length - valueLength) //  ZERO  for now, cant be zero
           case bsonArray2: Array[Any] =>
             val arr: Array[Byte] = Mapper.encode(newValue.asInstanceOf[Array[Any]])
-            (newBuffer.writeBytes(arr), 0) //  ZERO  for now, cant be zero
+            (newBuffer.writeBytes(arr), arr.length - valueLength) //  ZERO  for now, cant be zero
           case _ =>
             throw CustomException(s"Wrong inject type. Injecting type ${newValue.getClass.getSimpleName}. Value type require D_BSONARRAY (java List or scala Array)")
         }
@@ -553,131 +285,7 @@ class Injector {
     }
   }
 
-  //  def findFieldID(buffer: ByteBuf, fieldID: String, bufferSize: Int): (Int, Int) = {
-  //
-  //    //    while(buffer.readerIndex()< buffer.writerIndex()){
-  //    //      println(s"*** -> ${buffer.readByte()}")
-  //    //    }
-  //    //val bufferSize: Int = buffer.readIntLE()  //getIntLE(0)
-  //    println(s"findFieldID...........bufferSize: $bufferSize")
-  //    val startReaderIndex: Int = buffer.readerIndex()
-  //    if (startReaderIndex < (bufferSize - 1)) {
-  //      //buffer.readIntLE()// consume the size of the buffer
-  //      val fieldBytes: ListBuffer[Byte] = new ListBuffer[Byte]
-  //      val seqType: Int = buffer.readByte().toInt
-  //      println(s"findFieldID...........seqType: $seqType")
-  //      while (buffer.getByte(buffer.readerIndex()) != 0) {
-  //        fieldBytes.append(buffer.readByte())
-  //      }
-  //      buffer.readByte()
-  //      println(s"............... $fieldID")
-  //      println(s"............... ${new String(fieldBytes.toArray)}")
-  //      if (fieldID.toCharArray.deep == new String(fieldBytes.toArray).toCharArray.deep) {
-  //        println("FOUND NAME")
-  //        consume(seqType, buffer)
-  //        println(s"findFieldID...........startReaderIndex: $startReaderIndex, buffer.readerIndex() -> ${buffer.readerIndex()}")
-  //        (startReaderIndex, buffer.readerIndex())
-  //      } else {
-  //        println("DIDNT FOUND NAME")
-  //        // keep looking
-  //        consume(seqType, buffer)
-  //        findFieldID(buffer, fieldID, bufferSize)
-  //      }
-  //    } else {
-  //      println("No FieldID found!!")
-  //      //throw new NoSuchElementException(s" Field $fieldID doesn´t exist.")
-  //      (0, 0)
-  //    }
-  //  }
-
-  //  def updateValues(buffer: ByteBuf, f: (Any) => Any): ByteBuf = {
-  //    // new buffer to return
-  //    val newBuffer: ByteBuf = Unpooled.buffer()
-  //    //gget the seqType
-  //    val seqType: Int = buffer.readByte().toInt
-  //    println(s"updateValues!!!!!!!!!!!!!!!!!!!!seqType -> $seqType")
-  //    // get the name of the field
-  //    val fieldBytes: ListBuffer[Byte] = new ListBuffer[Byte]
-  //    while (buffer.getByte(buffer.readerIndex()) != 0) {
-  //      fieldBytes.append(buffer.readByte())
-  //    }
-  //    println(s"updateValues!!!!!!!!!!!!!!!!!!!!fieldBytes -> ${new String(fieldBytes.toArray)}")
-  //    fieldBytes.append(buffer.readByte()) //zero byte
-  //    // write the seqType in returning buffer
-  //    newBuffer.writeByte(seqType.toByte)
-  //    // write the field name in returning buffer
-  //    fieldBytes.foreach(b => newBuffer.writeByte(b))
-  //    // updated the new value in returning buffer
-  //    seqType match {
-  //      case D_ZERO_BYTE => None
-  //      case D_FLOAT_DOUBLE =>
-  //        // get the present value
-  //        val value: Double = buffer.readDoubleLE()
-  //        // apply the f function to the present value and obtain the new value
-  //        val newValue: Any = f(value)
-  //        // write the new value in the returning buffer
-  //        writeNewValue(newBuffer, newValue)
-  //      case D_ARRAYB_INST_STR_ENUM_CHRSEQ =>
-  //        // get the size of the value
-  //        val valueLength: Int = buffer.readIntLE()
-  //        // get the section of the buffer and copy it to a new buffer so we can use the array() function from ByteBuf Lib
-  //        val value: ByteBuf = Unpooled.copiedBuffer(buffer.readBytes(valueLength))
-  //        // get the value in Array[Byte] with the array() function
-  //        val array: Array[Byte] = value.array()
-  //        // apply the f function to the present value and obtain the new value
-  //        val newValue: Any = f(new String(array))
-  //        // write the new value in the returning buffer
-  //        println(s"updateValues!!!!!!!!!!!!!!!!!!!!valueLength -> $valueLength")
-  //        writeNewValue(newBuffer, newValue, seqType, valueLength) //(newbuffer, funcWithArg, 2, 2)
-  //      case D_BSONOBJECT =>
-  //        // get the size of the value
-  //        val valueTotalLength: Int = buffer.readIntLE() //TODO
-  //      // get the section of the buffer and copy it to a new buffer so we can use the array() function from ByteBuf Lib
-  //      val bsonObject: ByteBuf = Unpooled.copiedBuffer(buffer.readBytes(valueTotalLength - 4))
-  //        // apply the f function to the present value and obtain the new value
-  //        val newValue: Any = f(bsonObject)
-  //        // write the new value in the returning buffer
-  //        writeNewValue(newBuffer, newValue)
-  //      case D_BSONARRAY =>
-  //        // get the size of the value
-  //        val valueLength: Int = buffer.readIntLE() // TODO
-  //      // get the section of the buffer and copy it to a new buffer so we can use the array() function from ByteBuf Lib
-  //      val bsonArray: ByteBuf = buffer.readBytes(valueLength - 4)
-  //        // apply the f function to the present value and obtain the new value
-  //        val newValue: Any = f(bsonArray)
-  //        // write the new value in the returning buffer
-  //        writeNewValue(newBuffer, newValue)
-  //      case D_BOOLEAN =>
-  //        // get the value Boolean
-  //        val value: Int = buffer.readByte()
-  //        // apply the f function to the present value and obtain the new value
-  //        val newValue: Any = f(value)
-  //        // write the new value in the returning buffer
-  //        writeNewValue(newBuffer, newValue)
-  //      case D_NULL =>
-  //
-  //      case D_INT =>
-  //        // get the value Int
-  //        val value: Int = buffer.readIntLE()
-  //        // apply the f function to the present value and obtain the new value
-  //        val newValue: Any = f(value)
-  //        // write the new value in the returning buffer
-  //        writeNewValue(newBuffer, newValue)
-  //      case D_LONG =>
-  //        // get the value Long
-  //        val value: Long = buffer.readLongLE()
-  //        // apply the f function to the present value and obtain the new value
-  //        val newValue: Any = f(value)
-  //        // write the new value in the returning buffer
-  //        writeNewValue(newBuffer, newValue)
-  //      case _ =>
-  //    }
-  //    //return a ByteBuf with the the values updated
-  //
-  //    Unpooled.buffer(newBuffer.writerIndex()).writeBytes(newBuffer)
-  //  }
-
-  def consume(seqType: Int, buffer: ByteBuf, fieldID: String, f: Any => Any): Option[(ByteBuf, Int)] = {
+  private def consume(seqType: Int, buffer: ByteBuf, fieldID: String, f: Any => Any): Option[(ByteBuf, Int)] = {
     seqType match {
       case D_ZERO_BYTE => None
       case D_FLOAT_DOUBLE =>
@@ -742,83 +350,6 @@ class Injector {
     }
   }
 
-  //  def consume(seqType: Int, buffer: ByteBuf): Unit = {
-  //    seqType match {
-  //      case D_ZERO_BYTE => None
-  //      case D_FLOAT_DOUBLE =>
-  //        println("D_FLOAT_DOUBLE")
-  //        buffer.readDoubleLE()
-  //      case D_ARRAYB_INST_STR_ENUM_CHRSEQ =>
-  //        println("D_ARRAYB_INST_STR_ENUM_CHRSEQ")
-  //        val valueLength: Int = buffer.readIntLE()
-  //        buffer.readBytes(valueLength)
-  //      case D_BSONOBJECT =>
-  //        println("BSONOBJECT ")
-  //        val valueTotalLength: Int = buffer.readIntLE()
-  //        //println(valueTotalLength)
-  //        buffer.readBytes(valueTotalLength - 4)
-  //      case D_BSONARRAY =>
-  //        println("D_BSONARRAY")
-  //        val valueLength: Int = buffer.readIntLE()
-  //        buffer.readBytes(valueLength - 4)
-  //      case D_BOOLEAN =>
-  //        println("D_BOOLEAN")
-  //        buffer.readByte()
-  //      case D_NULL =>
-  //        println("D_NULL")
-  //      case D_INT =>
-  //        println("D_INT")
-  //        buffer.readIntLE()
-  //      case D_LONG =>
-  //        println("D_LONG")
-  //        buffer.readLongLE()
-  //      case _ =>
-  //    }
-  //  }
-
-  //  def writeNewValue(newBuffer: ByteBuf, newValue: Any, seqType: Int = 0, valueLength: Int = 0): Unit = {
-  //    val returningType: String = newValue.getClass.getSimpleName
-  //    // println("returning type = "+returningType)
-  //    // superclass to try to find a solution for enumerations
-  //    //val superclass: String = newValue.getClass.getGenericSuperclass.toString
-  //    //println("superclass type = "+superclass)
-  //    println(s"writeNewValue___________________________________returningType -> $returningType")
-  //    returningType match {
-  //      case "Integer" =>
-  //        newBuffer.writeIntLE(newValue.asInstanceOf[Int])
-  //      case "byte[]" =>
-  //        val aux: Array[Byte] = newValue.asInstanceOf[Array[Byte]]
-  //        newBuffer.writeIntLE(aux.length + 1).writeBytes(aux).writeByte(0)
-  //      case "String" =>
-  //        val aux: Array[Byte] = newValue.asInstanceOf[String].getBytes()
-  //        newBuffer.writeIntLE(aux.length + 1).writeBytes(aux).writeByte(0)
-  //      case "Instant" =>
-  //        val aux: Array[Byte] = newValue.asInstanceOf[Instant].toString.getBytes()
-  //        newBuffer.writeIntLE(aux.length + 1).writeBytes(aux).writeByte(0)
-  //      case "Enumerations" => //TODO
-  //
-  //      case "Float" =>
-  //        val aux: Float = newValue.asInstanceOf[Float]
-  //        newBuffer.writeDoubleLE(aux)
-  //      case "Double" =>
-  //        val aux: Double = newValue.asInstanceOf[Double]
-  //        newBuffer.writeDoubleLE(aux)
-  //      case "BsonObject" =>
-  //        val buf: Buffer = newValue.asInstanceOf[BsonObject].encode()
-  //        newBuffer.writeBytes(buf.getByteBuf)
-  //      case "Boolean" =>
-  //        newBuffer.writeBoolean(newValue.asInstanceOf[Boolean])
-  //      case "Long" =>
-  //        newBuffer.writeLongLE(newValue.asInstanceOf[Long])
-  //      case "BsonArray" =>
-  //        val buf: Buffer = newValue.asInstanceOf[BsonArray].encode()
-  //        newBuffer.writeBytes(buf.getByteBuf)
-  //
-  //      case _ if seqType == D_ARRAYB_INST_STR_ENUM_CHRSEQ => //enumerations
-  //        writeNewValue(newBuffer, newValue.toString)
-  //    }
-  //  }
-
   private def readArrayPos(netty: ByteBuf): Char = {
     val list: ListBuffer[Byte] = new ListBuffer[Byte]
     var i: Int = netty.readerIndex()
@@ -833,7 +364,7 @@ class Injector {
     stringList.head
   }
 
-  def findBsonObjectWithinBsonArray(buffer: ByteBuf, fieldID: String, f: Any => Any): (Option[ByteBuf], Int) = {
+  private def findBsonObjectWithinBsonArray(buffer: ByteBuf, fieldID: String, f: Any => Any): (Option[ByteBuf], Int) = {
     val seqType: Int = buffer.readByte()
     println(s"findBsonObjectWithinBsonArray____________________________seqType: $seqType")
     if (seqType == 0) {
@@ -852,193 +383,10 @@ class Injector {
           println("Another None AGAIN")
           findBsonObjectWithinBsonArray(buffer, fieldID, f)
       }
-//      processTypes(buffer, seqType, fieldID, f) map { elem =>
-//        println("out of processTypes and got Some")
-//        (elem._1,elem._2)
-//      } getOrElse {
-//        println("Another None AGAIN")
-//        findBsonObjectWithinBsonArray(buffer, fieldID, f)
-//      }
     }
   }
 
-  /*def findBsonObjectWithinBsonObject(buffer: ByteBuf): List[(Int, Int)] = {
-    //list result to keep the pairs for the bsonObjects positions
-    val listResult: ListBuffer[(Int, Int)] = new ListBuffer[(Int, Int)]
-    //the size of the received buffer
-    buffer.readIntLE() //buffSize
-    // while we dont reach the end of the buffer
-    while (buffer.readerIndex() < buffer.writerIndex() - 1) {
-      // get the type of the following value
-      val seqType: Int = buffer.readByte()
-      // fieldBytes will keep the name of the field
-      val fieldBytes: ListBuffer[Byte] = new ListBuffer[Byte]
-      // consume bytes until the name is complete, i.e, when we find a 0 byte
-      while (buffer.getByte(buffer.readerIndex()) != 0) {
-        fieldBytes.append(buffer.readByte())
-      }
-      println(s"findBsonObjectWithinBsonObject ---> ${new String(fieldBytes.toArray)}")
-      //consume the 0 byte
-      buffer.readByte()
-      // match and treat each type
-      processTypes(buffer, seqType).foreach(U => listResult.+=((U._1, U._2)))
-    }
-    // last zero of a BsonArray
-    buffer.readByte()
-    // return the list of pairs of positions of BsonObjects
-    listResult.toList
-  }*/
-
-  /*def arrayTreatment(buffer: ByteBuf, fieldID: String, f: Any => Any, indexesOfInterest: (Int, Int), indexesProcessed: Int = 0): ByteBuf = {
-
-    /////////////////////////
-    val bP: ByteProcessor = (value: Byte) => {
-      println("char= " + value.toChar + " int= " + value.toInt + " byte= " + value)
-      true
-    }
-    // get the buffer's Start Region Index and Finish Region Index
-    val (fieldStartIndex, fieldFinishIndex): (Int, Int) = (indexesOfInterest._1, indexesOfInterest._2)
-    println(s"fieldStartIndex -> $fieldStartIndex, fieldFinishIndex -> $fieldFinishIndex")
-    // Slice of the buffer corresponding to the section before the region of interest
-    val bufferOriginalSize: ByteBuf = buffer.slice(0, fieldStartIndex)
-    //println("++++++++++++++++++++++++")
-    //bufferOriginalSize.forEachByte(bP)
-    // Slice of the buffer's region of interest
-    val bufferOfInterst: ByteBuf = buffer.slice(fieldStartIndex, fieldFinishIndex - fieldStartIndex)
-    //println("++++++++++++++++++++++++")
-    //bufferOfInterst.forEachByte(bP)
-    // Slice of the buffer corresponding to the section after the region of interest
-    val bufferRemainder: ByteBuf = buffer.slice(fieldFinishIndex, buffer.getIntLE(0) - fieldFinishIndex)
-    //println("++++++++++++++++++++++++")
-    //bufferRemainder.forEachByte(bP)
-    //println("++++++++++++++++++++++++")
-    // Execute the updated of the field FieldID with function f
-    // The function findFieldID throws an Exception case no field with FieldID exists.
-    // Use the Try the catch the exception and keep processing the rest of the pairs
-    println("bufferOfInterst inside START = " + bufferOfInterst.capacity())
-    val newBuffer: ByteBuf = start(bufferOfInterst, fieldID, f)
-    // Update the number of pairs processed
-    println("AFTER START")
-    newBuffer.forEachByte(bP)
-    val newListIndexesProcessed: Int = indexesProcessed + 1
-    /*
-        // Compute a new Buffer corresponding to the section of the size with the size of the buffer
-        val byteBufOriginalSize: ByteBuf = Unpooled.buffer(4).writeIntLE(bufferOriginalSize.capacity() + newBufferT.get.capacity() + bufferRemainder.capacity())
-        // Slice of the region after the ByteBuf size and before the region of interest
-        val remainingOfSizeBuffer: ByteBuf = bufferOriginalSize.slice(4, bufferOriginalSize.capacity() - 4)
-        // Create a new ByteBuf with all the ByteBuf that were sliced and updated
-        val result: ByteBuf = Unpooled.wrappedBuffer(byteBufOriginalSize, remainingOfSizeBuffer, newBufferT.get, bufferRemainder)
-    */
-
-    // Compute a new Buffer corresponding to the section of the size with the size of the buffer
-    val byteBufOriginalSize: ByteBuf = Unpooled.buffer(4).writeIntLE(bufferOriginalSize.capacity() + newBuffer.capacity() + bufferRemainder.capacity())
-    println(s"arrayTreatment::::::bufferOriginalSize.capacity() -> ${bufferOriginalSize.capacity()}::::::newBuffer.capacity() -> ${newBuffer.capacity()}:::::::bufferRemainder.capacity() -> ${bufferRemainder.capacity()}")
-    // Slice of the region after the ByteBuf size and before the region of interest
-    val remainingOfSizeBuffer: ByteBuf = bufferOriginalSize.slice(4, bufferOriginalSize.capacity() - 4)
-    // Create a new ByteBuf with all the ByteBuf that were sliced and updated
-    val result: ByteBuf = Unpooled.wrappedBuffer(byteBufOriginalSize, remainingOfSizeBuffer, newBuffer, bufferRemainder)
-
-    // println("After GLUEING averything together")
-    //result.forEachByte(bP)
-
-    val indexesOfInterestAux: List[(Int, Int)] = findBsonObjectWithinBsonArray(result.duplicate())
-    val newList: List[(Int, Int)] = indexesOfInterestAux.drop(newListIndexesProcessed)
-    println(newList)
-    val res: ByteBuf =
-      if (newList.isEmpty) {
-        println("isEmpty!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1")
-        result
-      } else {
-        arrayTreatment(result.duplicate(), fieldID, f, newList.head, newListIndexesProcessed)
-      }
-    res
-  }*/
-
-  /*def objectTreatment(buffer: ByteBuf, fieldID: String, f: Any => Any, indexesOfInterest: (Int, Int), indexesProcessed: Int = -1): ByteBuf = {
-    // get the buffer's Start Region Index and Finish Region Index
-    val (fieldStartIndex, fieldFinishIndex): (Int, Int) = (indexesOfInterest._1, indexesOfInterest._2)
-    println(s"fieldStartIndex -> $fieldStartIndex, fieldFinishIndex -> $fieldFinishIndex")
-    // Slice of the buffer corresponding to the section before the region of interest
-    val bufferOriginalSize: ByteBuf = buffer.slice(0, fieldStartIndex)
-    // Slice of the buffer's region of interest
-    val bufferOfInterst: ByteBuf = buffer.slice(fieldStartIndex, fieldFinishIndex - fieldStartIndex)
-    // Slice of the buffer corresponding to the section after the region of interest
-    val bufferRemainder: ByteBuf = buffer.slice(fieldFinishIndex, buffer.getIntLE(0) - fieldFinishIndex)
-    // Execute the updated of the field FieldID with function f
-    // The function findFieldID throws an Exception case no field with FieldID exists.
-    // Use the Try the catch the exception and keep processing the rest of the pairs
-    println("bufferOfInterst inside START = " + bufferOfInterst.capacity())
-    val newBuffer: ByteBuf = start(bufferOfInterst, fieldID, f)
-    // Update the number of pairs processed
-    println("AFTER START")
-    val newListIndexesProcessed: Int = indexesProcessed + 1
-    // Compute a new Buffer corresponding to the section of the size with the size of the buffer
-    val byteBufOriginalSize: ByteBuf = Unpooled.buffer(4).writeIntLE(bufferOriginalSize.capacity() + newBuffer.capacity() + bufferRemainder.capacity()) //NEW TOTAL LENGTH
-    // Slice of the region after the ByteBuf size and before the region of interest
-    val result: ByteBuf =
-    if (bufferOriginalSize.capacity() == 0) {
-      // Create a new ByteBuf with all the ByteBuf that were sliced and updated
-      newBuffer.readIntLE() // consume the length so it wont be wrapped twice
-      Unpooled.wrappedBuffer(byteBufOriginalSize, newBuffer)
-    } else {
-      val remainingOfSizeBuffer: ByteBuf = bufferOriginalSize.slice(4, bufferOriginalSize.capacity() - 4) //BEFORE WITHOUT THE TOTAL SIZE
-      // Create a new ByteBuf with all the ByteBuf that were sliced and updated
-      Unpooled.wrappedBuffer(byteBufOriginalSize, remainingOfSizeBuffer, newBuffer, bufferRemainder)
-    }
-
-    val indexesOfInterestAux: List[(Int, Int)] = findBsonObjectWithinBsonObject(result.duplicate())
-    val newList: List[(Int, Int)] = indexesOfInterestAux.drop(newListIndexesProcessed)
-    println(newList)
-    val res: ByteBuf =
-      if (newList.isEmpty) {
-        result
-      } else {
-        objectTreatment(result.duplicate(), fieldID, f, newList.head, newListIndexesProcessed)
-      }
-    res
-  }*/
-
-  //  def start(buffer: ByteBuf, fieldID: String, f: Any => Any): ByteBuf = {
-  //    // val failureBuffer: ByteBuf = buffer.duplicate()
-  //    // get the size of the buffer without consumes the bytes
-  //    // val bufferSize: Int = buffer.readIntLE()
-  //    val bufaux: ByteBuf = Unpooled.buffer(buffer.getIntLE(0)).writeBytes(buffer.duplicate())
-  //
-  //    // compute the region of interest of the buffer corresponding to the fieldID
-  //    val bufferSize: Int = buffer.readIntLE()
-  //    println(s"start--------------> bufferSize: $bufferSize")
-  //    val (fieldStartIndex: Int, fieldFinishIndex: Int) = findFieldID(buffer, fieldID, bufferSize) //first time the start is 4 and finish is 17
-  //    //println(s"$fieldStartIndex -> $fieldFinishIndex")
-  //    // Slice of the buffer corresponding to the section before the region of interest
-  //
-  //    (fieldStartIndex, fieldFinishIndex) match {
-  //      case (0, 0) =>
-  //        bufaux
-  //      case (_, _) =>
-  //        val bufferOriginalSize: ByteBuf = buffer.slice(0, fieldStartIndex) //(0,4length) = (0,3)
-  //      // Slice of the buffer's region of interest
-  //      val bufferOfInterst: ByteBuf = buffer.slice(fieldStartIndex, fieldFinishIndex - fieldStartIndex) //(4,13length) = (4,17)
-  //      // Slice of the buffer corresponding to the section after the region of interest
-  //      val bufferRemainder: ByteBuf = buffer.slice(fieldFinishIndex, buffer.getIntLE(0) - fieldFinishIndex) //(17,1length) = (17,18)
-  //
-  //
-  //        // Compute the new buffer with the value of FieldID updated with function f
-  //        val newBuffer: ByteBuf = updateValues(bufferOfInterst, f) //buffer has everything written correctly
-  //      // Compute a new Buffer corresponding to the section of the size with the size of the buffer
-  //      val byteBufOriginalSize: ByteBuf = Unpooled.buffer(4).writeIntLE(bufferOriginalSize.capacity() + newBuffer.capacity() + bufferRemainder.capacity())
-  //        println(s"start -------bufferOriginalSize.capacity(): ${bufferOriginalSize.capacity()}-------newBuffer.capacity(): ${newBuffer.capacity()}------bufferRemainder.capacity(): ${bufferRemainder.capacity()}")
-  //        // Slice of the region after the ByteBuf size and before the region of interest
-  //        val remainingOfSizeBuffer: ByteBuf = bufferOriginalSize.slice(4, bufferOriginalSize.capacity() - 4)
-  //        println(s"start---------remainingOfSizeBuffer.capacity(): ${remainingOfSizeBuffer.capacity()}")
-  //        // Create a new ByteBuf with all the ByteBuf that were sliced and updated
-  //        val result: ByteBuf = Unpooled.wrappedBuffer(byteBufOriginalSize, remainingOfSizeBuffer, newBuffer, bufferRemainder) //(totalSize, 0, buffer with new value, finishing byte buffer)
-  //        // return the new Buffer
-  //        println("Size of failure buffer = " + buffer.capacity() + " result buffer = " + result.capacity())
-  //        result
-  //    }
-  //  }
-
-  def processTypes(buffer: ByteBuf, seqType: Int, fieldID: String, f: Any => Any): Option[(ByteBuf, Int)] = {
+  private def processTypes(buffer: ByteBuf, seqType: Int, fieldID: String, f: Any => Any): Option[(ByteBuf, Int)] = {
     seqType match {
       case D_ZERO_BYTE =>
         println("case zero_byte")

--- a/src/main/scala/io/boson/injectors/Injector.scala
+++ b/src/main/scala/io/boson/injectors/Injector.scala
@@ -282,7 +282,7 @@ class Injector {
               throw CustomException(s"Wrong inject type. Injecting type ${value.getClass.getSimpleName}. Value type require D_BOOLEAN")
             }
         }
-      case D_NULL => (newBuffer, 0) //  returns empty buffer
+      case D_NULL =>  throw CustomException(s"NULL field. Can not be changed") //  returns empty buffer
       case D_INT =>
         val value: Any = f(buffer.readIntLE())
         value match {

--- a/src/main/scala/io/boson/injectors/Injector.scala
+++ b/src/main/scala/io/boson/injectors/Injector.scala
@@ -215,7 +215,7 @@ class Injector {
       case D_ARRAYB_INST_STR_ENUM_CHRSEQ =>
         val length: Int = buffer.readIntLE()
         val value: Any = f(new String(Unpooled.copiedBuffer(buffer.readBytes(length)).array()))
-        println("returning type = " + value.getClass.getSimpleName)
+        //println("returning type = " + value.getClass.getSimpleName)
         value match {
           case n: Array[Byte] =>
             (newBuffer.writeIntLE(n.length + 1).writeBytes(n).writeByte(0), (n.length + 1) - length)

--- a/src/test/scala/io/boson/InjectorsTest.scala
+++ b/src/test/scala/io/boson/InjectorsTest.scala
@@ -36,6 +36,7 @@ class InjectorsTest extends FunSuite {
   val newFloat: Float = 15.toFloat
   val double: Double = 21.toDouble
   val newDouble: Double = 25.toDouble
+
   val bObj: BsonObject = new BsonObject().put("bsonObj", "ola")
   val newbObj: BsonObject = new BsonObject().put("newbsonObj", "newbsonObj")
   val bool: Boolean = true

--- a/src/test/scala/io/boson/InjectorsTest.scala
+++ b/src/test/scala/io/boson/InjectorsTest.scala
@@ -182,7 +182,7 @@ class InjectorsTest extends FunSuite {
 
   test("Injector: BsonObject => BsonObject") {
 
-    val b1: Option[Boson] = inj.modify(netty, "bObj", _ => newbObj)
+    val b1: Option[Boson] = inj.modify(netty, "bObj", _ => newbObj.getMap)
 
     val result: Any = b1 match {
       case None => List()
@@ -223,7 +223,7 @@ class InjectorsTest extends FunSuite {
   }
 
   test("Injector: BsonArray => BsonArray") {
-    val b1: Option[Boson] = inj.modify(netty, "bsonArray", _ => newbsonArray)
+    val b1: Option[Boson] = inj.modify(netty, "bsonArray", _ => newbsonArray.getList)
 
     val result: Any = b1 match {
       case None => List()
@@ -351,7 +351,7 @@ class InjectorsTest extends FunSuite {
 
   test("Injector BsonArray: BsonObject => BsonObject") {
 
-    val b1: Option[Boson] = inj.modify(nettyArray, "bObj", _ => newbObj)
+    val b1: Option[Boson] = inj.modify(nettyArray, "bObj", _ => newbObj.getMap)
 
     val result: Any = b1 match {
       case None => List()
@@ -393,7 +393,7 @@ class InjectorsTest extends FunSuite {
 
   test("Injector BsonArray: BsonArray => BsonArray") {
 
-    val b1: Option[Boson] = inj.modify(nettyArray, "bsonArray", _ => newbsonArray)
+    val b1: Option[Boson] = inj.modify(nettyArray, "bsonArray", _ => newbsonArray.getList)
 
     val result: Any = b1 match {
       case None => List()

--- a/src/test/scala/io/boson/TypeConsistencyTests.scala
+++ b/src/test/scala/io/boson/TypeConsistencyTests.scala
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
+import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 /**
   * Created by Ricardo Martins on 13/12/2017.
@@ -805,7 +806,7 @@ class TypeConsistencyTests extends FunSuite {
   }
 
 
-  test("Injector: Type Consistency String/Array[Byte]") {
+  test("Injector: Type Consistency String/Array[Byte] -> Float") {
     val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23.0f).get)
@@ -822,8 +823,144 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type Float. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
   }
+  test("Injector: Type Consistency String/Array[Byte] -> Int") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Integer. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
+  test("Injector: Type Consistency String/Array[Byte] -> Long") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23L).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Long. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
+  test("Injector: Type Consistency String/Array[Byte] -> Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => true).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Boolean. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
+  test("Injector: Type Consistency String/Array[Byte] -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => null).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
+  test("Injector: Type Consistency String/Array[Byte] -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => None).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
+  test("Injector: Type Consistency String/Array[Byte] -> Double") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23.0).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Double. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
+  test("Injector: Type Consistency String/Array[Byte] -> BsonObject") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonObject().put("anything", 2).getMap).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type LinkedHashMap. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
+  test("Injector: Type Consistency String/Array[Byte] -> BsonArray") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonArray().add("anything").getList).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type ArrayList. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
 
-  test("Injector: Type Consistency Float/Double") {
+  test("Injector: Type Consistency Float/Double -> Int") {
     val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23).get)
@@ -840,8 +977,127 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type Integer. Value type require D_FLOAT_DOUBLE" === result)
   }
+  test("Injector: Type Consistency Float/Double -> Long") {
+    val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23L).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Long. Value type require D_FLOAT_DOUBLE" === result)
+  }
+  test("Injector: Type Consistency Float/Double -> Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => true).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Boolean. Value type require D_FLOAT_DOUBLE" === result)
+  }
+  test("Injector: Type Consistency Float/Double -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => null).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_FLOAT_DOUBLE" === result)
+  }
+  test("Injector: Type Consistency Float/Double -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => None).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_FLOAT_DOUBLE" === result)
+  }
+  test("Injector: Type Consistency Float/Double -> BsonObject") {
+    val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonObject().put("anything", 2).getMap).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type LinkedHashMap. Value type require D_FLOAT_DOUBLE" === result)
+  }
+  test("Injector: Type Consistency Float/Double -> BsonArray") {
+    val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonArray().add(2).getList).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type ArrayList. Value type require D_FLOAT_DOUBLE" === result)
+  }
+  test("Injector: Type Consistency Float/Double -> String") {
+    val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => "dcfdf").get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type String. Value type require D_FLOAT_DOUBLE" === result)
+  }
 
-  test("Horrible Simple Injector: Type Consistency Int") {
+  test("Horrible Simple Injector: Type Consistency Int -> Float") {
     val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => 23.0f).get)
@@ -858,8 +1114,144 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type Float. Value type require D_INT" === result)
   }
+  test("Horrible Simple Injector: Type Consistency Int -> Double") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => 23.0).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Double. Value type require D_INT" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency Int -> Long") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => 23L).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Long. Value type require D_INT" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency Int -> Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => true).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Boolean. Value type require D_INT" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency Int -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => null).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_INT" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency Int -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => None).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_INT" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency Int -> String") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => "sdvknsd").get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type String. Value type require D_INT" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency Int -> BsonObject") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => new BsonObject().put("anything", 2).getMap ).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type LinkedHashMap. Value type require D_INT" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency Int -> BsonArray") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2", 10))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => new BsonArray().add(2).getList).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type ArrayList. Value type require D_INT" === result)
+  }
 
-  test("Horrible Simple Injector: Type Consistency BsonObject") {
+  test("Horrible Simple Injector: Type Consistency BsonObject -> BsonArray") {
     val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => new BsonArray().add(2).getList).get)
@@ -877,4 +1269,149 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type ArrayList. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
   }
+  test("Horrible Simple Injector: Type Consistency BsonObject -> Int") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => 1).get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Integer. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency BsonObject -> Long") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => 12L).get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Long. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency BsonObject -> Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => true).get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Boolean. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency BsonObject -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => null).get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency BsonObject -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => None).get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency BsonObject -> String") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => "svwv").get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type String. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency BsonObject -> Float") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => 23.0f).get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Float. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Horrible Simple Injector: Type Consistency BsonObject -> Double") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => 52.0).get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "key2", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Double. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+
 }

--- a/src/test/scala/io/boson/TypeConsistencyTests.scala
+++ b/src/test/scala/io/boson/TypeConsistencyTests.scala
@@ -1414,4 +1414,23 @@ class TypeConsistencyTests extends FunSuite {
     assert("Wrong inject type. Injecting type Double. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
   }
 
+
+  test("Horrible Simple Injector: Type Consistency Null -> Double") {
+    val bson: BsonObject = new BsonObject().putNull("Null").put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Null", _ => 52.0).get)
+
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Null", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("NULL field. Can not be changed" === result)
+  }
 }

--- a/src/test/scala/io/boson/TypeConsistencyTests.scala
+++ b/src/test/scala/io/boson/TypeConsistencyTests.scala
@@ -1,0 +1,152 @@
+package io.boson
+
+import java.time.Instant
+
+import io.boson.bson.{BsonArray, BsonObject}
+import io.boson.bsonValue.BsSeq
+import io.boson.injectors.Testing1.{b1, bP}
+import io.boson.injectors.{EnumerationTest, Injector}
+import io.boson.nettyboson.Boson
+import io.boson.scalaInterface.ScalaInterface
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.{Failure, Success, Try}
+/**
+  * Created by Ricardo Martins on 13/12/2017.
+  */
+@RunWith(classOf[JUnitRunner])
+class TypeConsistencyTests extends FunSuite {
+
+  val inj: Injector = new Injector
+  val ext = new ScalaInterface
+
+
+  test("Injector: Type Consistency Ints") {
+   val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => "w").get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type String. Value type require D_INT" === result)
+  }
+
+  test("Injector: Type Consistency Long") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 1000).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Integer. Value type require D_LONG" === result)
+  }
+
+  test("Injector: Type Consistency Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 851).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Integer. Value type require D_BOOLEAN" === result)
+  }
+
+  test("Injector: Type Consistency BsonArray") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 851).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Integer. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
+
+  test("Injector: Type Consistency BsonObject") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23.0f).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Float. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+
+  test("Injector: Type Consistency String/Array[Byte]") {
+    val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23.0f).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Float. Value type require D_ARRAYB_INST_STR_ENUM_CHRSEQ" === result)
+  }
+
+  test("Injector: Type Consistency Float/Double") {
+    val bson: BsonObject = new BsonObject().put("Hi",1.0f).put("Bye",25.1f)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Integer. Value type require D_FLOAT_DOUBLE" === result)
+  }
+
+}

--- a/src/test/scala/io/boson/TypeConsistencyTests.scala
+++ b/src/test/scala/io/boson/TypeConsistencyTests.scala
@@ -27,7 +27,7 @@ class TypeConsistencyTests extends FunSuite {
   val ext = new ScalaInterface
 
 
-  test("Injector: Type Consistency Int") {
+  test("Injector: Type Consistency Int -> String") {
    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => "w").get)
@@ -44,8 +44,151 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type String. Value type require D_INT" === result)
   }
+  test("Injector: Type Consistency Int -> Long") {
+    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 1L).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Long. Value type require D_INT" === result)
+  }
+  test("Injector: Type Consistency Int -> Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => true).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Boolean. Value type require D_INT" === result)
+  }
+  test("Injector: Type Consistency Int -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => null).get)
+    // b1.get.getByteBuf.forEachByte(bP)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println("Success "+value)
+        value
+      case Failure(e) =>
 
-  test("Injector: Type Consistency Long") {
+        println("Failure "+e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_INT" === result)
+  }
+  test("Injector: Type Consistency Int -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => None).get)
+    // b1.get.getByteBuf.forEachByte(bP)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_INT" === result)
+  }
+  test("Injector: Type Consistency Int -> Double") {
+    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 2.1).get)
+    // b1.get.getByteBuf.forEachByte(bP)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Double. Value type require D_INT" === result)
+  }
+  test("Injector: Type Consistency Int -> Float") {
+    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 2.1f).get)
+    // b1.get.getByteBuf.forEachByte(bP)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Float. Value type require D_INT" === result)
+  }
+  test("Injector: Type Consistency Int -> BsonObject") {
+    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonObject().put("anything", 5).getMap).get)
+    // b1.get.getByteBuf.forEachByte(bP)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type LinkedHashMap. Value type require D_INT" === result)
+  }
+  test("Injector: Type Consistency Int -> BsonArray") {
+    val bson: BsonObject = new BsonObject().put("Hi", 1).put("Bye", 2)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonArray().add("anything").getList).get)
+    // b1.get.getByteBuf.forEachByte(bP)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type ArrayList. Value type require D_INT" === result)
+  }
+
+  test("Injector: Type Consistency Long -> Int") {
     val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 1000).get)
@@ -62,8 +205,144 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type Integer. Value type require D_LONG" === result)
   }
+  test("Injector: Type Consistency Long -> Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => true).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Boolean. Value type require D_LONG" === result)
+  }
+  test("Injector: Type Consistency Long -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => null).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_LONG" === result)
+  }
+  test("Injector: Type Consistency Long -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => None).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_LONG" === result)
+  }
+  test("Injector: Type Consistency Long -> Double") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 2.3).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Double. Value type require D_LONG" === result)
+  }
+  test("Injector: Type Consistency Long -> Float") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 2.3f).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Float. Value type require D_LONG" === result)
+  }
+  test("Injector: Type Consistency Long -> BsonObject") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonObject().put("anything", 2).getMap).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type LinkedHashMap. Value type require D_LONG" === result)
+  }
+  test("Injector: Type Consistency Long -> BsonArray") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonArray().add("anything").getList).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type ArrayList. Value type require D_LONG" === result)
+  }
+  test("Injector: Type Consistency Long -> String") {
+    val bson: BsonObject = new BsonObject().put("Hi", 10L).put("Bye", 200L)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => "String").get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type String. Value type require D_LONG" === result)
+  }
 
-  test("Injector: Type Consistency Boolean") {
+  test("Injector: Type Consistency Boolean -> Int") {
     val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 851).get)
@@ -80,8 +359,144 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type Integer. Value type require D_BOOLEAN" === result)
   }
+  test("Injector: Type Consistency Boolean -> Long") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 851L).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Long. Value type require D_BOOLEAN" === result)
+  }
+  test("Injector: Type Consistency Boolean -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => null).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_BOOLEAN" === result)
+  }
+  test("Injector: Type Consistency Boolean -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => None).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_BOOLEAN" === result)
+  }
+  test("Injector: Type Consistency Boolean -> String") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => "String").get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type String. Value type require D_BOOLEAN" === result)
+  }
+  test("Injector: Type Consistency Boolean -> BsonObject") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonObject().put("sdfw", 2).getMap).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type LinkedHashMap. Value type require D_BOOLEAN" === result)
+  }
+  test("Injector: Type Consistency Boolean -> BsonArray") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonArray().add("sdfw").getList).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type ArrayList. Value type require D_BOOLEAN" === result)
+  }
+  test("Injector: Type Consistency Boolean -> Double") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 2.3).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Double. Value type require D_BOOLEAN" === result)
+  }
+  test("Injector: Type Consistency Boolean -> Float") {
+    val bson: BsonObject = new BsonObject().put("Hi", true).put("Bye", false)
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 2.3f).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Float. Value type require D_BOOLEAN" === result)
+  }
 
-  test("Injector: Type Consistency BsonArray") {
+  test("Injector: Type Consistency BsonArray -> Int") {
     val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 851).get)
@@ -98,8 +513,161 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type Integer. Value type require D_BSONARRAY (java List or scala Array)" === result)
   }
+  test("Injector: Type Consistency BsonArray -> Long") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 851L).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Long. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
+  test("Injector: Type Consistency BsonArray -> Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => true).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Boolean. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
+  test("Injector: Type Consistency BsonArray -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => None).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
+  test("Injector: Type Consistency BsonArray -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => null).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
+  test("Injector: Type Consistency BsonArray -> BsonObject") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonObject().put("anything", 2).getMap).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type LinkedHashMap. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
+  test("Injector: Type Consistency BsonArray -> String") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => "String").get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type String. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
+  test("Injector: Type Consistency BsonArray -> Double") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 2.3).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Double. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
+  test("Injector: Type Consistency BsonArray -> Float") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(1)).put("Bye", new BsonArray().add(2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 2.3f).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Float. Value type require D_BSONARRAY (java List or scala Array)" === result)
+  }
 
-  test("Injector: Type Consistency BsonObject") {
+  test("Injector: Type Consistency BsonObject -> Int") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 851).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Integer. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Injector: Type Consistency BsonObject -> Float") {
     val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23.0f).get)
@@ -116,6 +684,126 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type Float. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
   }
+  test("Injector: Type Consistency BsonObject -> Long") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23L).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Long. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Injector: Type Consistency BsonObject -> Boolean") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => true).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Boolean. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Injector: Type Consistency BsonObject -> null") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => null).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type NULL. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Injector: Type Consistency BsonObject -> None") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => None).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type None$. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Injector: Type Consistency BsonObject -> BsonArray") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => new BsonArray().add(2).getList).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type ArrayList. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Injector: Type Consistency BsonObject -> String") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => "fde").get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type String. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+  test("Injector: Type Consistency BsonObject -> Double") {
+    val bson: BsonObject = new BsonObject().put("Hi", new BsonObject().put("Ola", 1)).put("Bye", new BsonObject().put("Adeus", 2))
+    val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
+    val b1: Try[Boson] = Try(inj.modify(netty, "Hi", _ => 23.0).get)
+    val result: Any = b1 match {
+      case Success(v) =>
+        val sI: ScalaInterface = new ScalaInterface
+        println("Extracting the field injected with value: ")
+        val value: Any = sI.parse(v, "Hi", "all").asInstanceOf[BsSeq].value.head
+        println(value)
+        value
+      case Failure(e) =>
+        println(e.getMessage)
+        e.getMessage
+    }
+    assert("Wrong inject type. Injecting type Double. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
+  }
+
 
   test("Injector: Type Consistency String/Array[Byte]") {
     val bson: BsonObject = new BsonObject().put("Hi","Olá").put("Bye","Adeus")
@@ -175,7 +863,7 @@ class TypeConsistencyTests extends FunSuite {
     val bson: BsonObject = new BsonObject().put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)
     val netty: Option[Boson] = Option(ext.createBoson(bson.encode().getBytes))
     val b1: Try[Boson] = Try(inj.modify(netty, "key2", _ => new BsonArray().add(2).getList).get)
-   // b1.get.getByteBuf.forEachByte(bP)
+
     val result: Any = b1 match {
       case Success(v) =>
         val sI: ScalaInterface = new ScalaInterface

--- a/src/test/scala/io/boson/TypeConsistencyTests.scala
+++ b/src/test/scala/io/boson/TypeConsistencyTests.scala
@@ -1,7 +1,5 @@
 package io.boson
 
-import java.time.Instant
-
 import io.boson.bson.{BsonArray, BsonObject}
 import io.boson.bsonValue.BsSeq
 import io.boson.injectors.Injector
@@ -11,8 +9,6 @@ import io.netty.util.ByteProcessor
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
-
-import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 /**
   * Created by Ricardo Martins on 13/12/2017.
@@ -1413,7 +1409,6 @@ class TypeConsistencyTests extends FunSuite {
     }
     assert("Wrong inject type. Injecting type Double. Value type require D_BSONOBJECT (java util.Map[String, _] or scala Map[String, Any])" === result)
   }
-
 
   test("Horrible Simple Injector: Type Consistency Null -> Double") {
     val bson: BsonObject = new BsonObject().putNull("Null").put("Hi", new BsonArray().add(0).add(1).add(2).add(new BsonObject().put("key", "code").put("key1", new BsonArray().add(new BsonArray().add(1000L)).add(new BsonObject().put("key2",new BsonObject().put("key3", "code3")))))).put("Bye",25.1f)

--- a/src/test/scala/io/boson/TypeConsistencyTests.scala
+++ b/src/test/scala/io/boson/TypeConsistencyTests.scala
@@ -4,8 +4,7 @@ import java.time.Instant
 
 import io.boson.bson.{BsonArray, BsonObject}
 import io.boson.bsonValue.BsSeq
-import io.boson.injectors.Testing1.{b1, bP}
-import io.boson.injectors.{EnumerationTest, Injector}
+import io.boson.injectors.Injector
 import io.boson.nettyboson.Boson
 import io.boson.scalaInterface.ScalaInterface
 import org.junit.runner.RunWith


### PR DESCRIPTION
Issue #10 Injector type consistency fixed. 
Tests created to tests the consistency of value types with the injector.
Tested for all types. 
BsonArrays treated had ArrayLists. 
BsonObjects treated had LinkedHashMap. 
Null and None also considered in tests.



