### PR TITLE
Remove maps and lists

### DIFF
--- a/src/main/scala/io/boson/bson/bsonImpl/BosonExtractor.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/BosonExtractor.scala
@@ -21,10 +21,8 @@ class BosonExtractor[T](expression: String, extractFunction: java.util.function.
       }
     } catch {
       case e: RuntimeException =>
-        //println("RuntimeException")
         bsonValue.BsObject.toBson(e.getMessage)
       case e: java.lang.IndexOutOfBoundsException =>
-       // println(e.getMessage)
         bsonValue.BsObject.toBson(e.getMessage)
     }
   }

--- a/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
@@ -807,7 +807,7 @@ class BosonImpl(
                       }
                     case _ if keyList.head._2.equals(C_NEXT) | keyList.head._2.equals(C_LEVEL) => errorAnalyzer(limitList.head._3)
                     case _ =>
-                      val midResult = extractFromBsonArray(netty,valueLength2, finishReaderIndex, keyList, limitList.drop(1))
+                      val midResult: Iterable[Any] = extractFromBsonArray(netty,valueLength2, finishReaderIndex, keyList, limitList.drop(1))
                       if(midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                   }
                 case Some(_) =>
@@ -830,7 +830,7 @@ class BosonImpl(
                         case _ if keyList.head._2.equals(C_NEXT) | keyList.head._2.equals(C_LEVEL) => errorAnalyzer(limitList.head._3)
                         case _ =>
                           println("calling extractFromBsonArray")
-                          val midResult = extractFromBsonArray(netty,valueLength2, finishReaderIndex, keyList, limitList.drop(1))
+                          val midResult: Iterable[Any] = extractFromBsonArray(netty,valueLength2, finishReaderIndex, keyList, limitList.drop(1))
                           if(midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                       }
                     case Some(_) =>
@@ -849,7 +849,7 @@ class BosonImpl(
                             case Some(x) => Some(resultComposer(x.toVector))
                           }
                         case _ if keyList.head._2.equals(C_FILTER)=>
-                          val midResult = extractFromBsonArray(netty,valueLength2, finishReaderIndex, keyList, limitList.drop(1))
+                          val midResult: Iterable[Any] = extractFromBsonArray(netty,valueLength2, finishReaderIndex, keyList, limitList.drop(1))
                           if(midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                         case _ =>
                           netty.readerIndex(finishReaderIndex)
@@ -1418,11 +1418,11 @@ class BosonImpl(
                     case (D_BSONOBJECT | D_BSONARRAY) =>
                       val size:Int = buffer.getIntLE(buffer.readerIndex())
                       val buf1: ByteBuf = buffer.readBytes(size)
-                      val buf2:ByteBuf = Unpooled.buffer()
-                      modifierAll(buf1, dataType, f, buf2 )
+                      val buf2:ByteBuf = execStatementPatternMatch(buf1, list, f)
                       buf1.release()
-                      buf2.capacity(buf2.writerIndex())
-                      val buf3: ByteBuf = execStatementPatternMatch(buf2, list, f)
+                      val buf3: ByteBuf = Unpooled.buffer()
+                      modifierAll(buf2, dataType, f, buf3 )
+                      buf3.capacity(buf3.writerIndex())
                       buf2.release()
                       result.writeBytes(buf3)
                       buf3.release()

--- a/src/main/scala/io/boson/bson/bsonImpl/BosonInjector.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/BosonInjector.scala
@@ -15,11 +15,6 @@ import scala.compat.java8.FunctionConverters._
 
 class BosonInjector[T](expression: String, injectFunction: Function[T, T]) extends bson.Boson {
 
-  /*val bP: ByteProcessor = (value: Byte) => {
-    println("char= " + value.toChar + " int= " + value.toInt + " byte= " + value)
-    true
-  }*/
-
   val anon: T => T = injectFunction.asScala
 
   def parseInj[K](netty: BosonImpl, injectFunction: K => K , expression: String):bsonValue.BsValue = {
@@ -40,52 +35,34 @@ class BosonInjector[T](expression: String, injectFunction: Function[T, T]) exten
 
   override def go(bsonByteEncoding: Array[Byte]): CompletableFuture[Array[Byte]] = {
     val boson: io.boson.bson.bsonImpl.BosonImpl = new BosonImpl(byteArray = Option(bsonByteEncoding))
-//    println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
-//    boson.getByteBuf.forEachByte(bP)
-//    println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
     val future: CompletableFuture[Array[Byte]] =
       CompletableFuture.supplyAsync(() =>{
-
       val r: Array[Byte] = parseInj(boson, anon, expression) match {
         case ex: BsException => println(ex.getValue)
           bsonByteEncoding
         case nb: BsBoson =>
           nb.getValue.getByteBuf.array()
-        case x =>
-
+        case _ =>
           bsonByteEncoding
       }
-
       r
     })
-//    boson.getByteBuf.forEachByte(bP)
-//    println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
-    //future.get()
     future
   }
 
   override def go(bsonByteBufferEncoding: ByteBuffer): CompletableFuture[ByteBuffer] = {
     val boson: io.boson.bson.bsonImpl.BosonImpl = new BosonImpl(javaByteBuf = Option(bsonByteBufferEncoding))
-    //    println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
-    //    boson.getByteBuf.forEachByte(bP)
-    //    println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
     val future: CompletableFuture[ByteBuffer] =
     CompletableFuture.supplyAsync(() =>{
-
       val r:ByteBuffer = parseInj(boson, anon, expression) match {
         case ex: BsException => println(ex.getValue)
           bsonByteBufferEncoding
         case nb: BsBoson => nb.getValue.getByteBuf.nioBuffer()
-        case x =>
-
+        case _ =>
           bsonByteBufferEncoding
       }
-
       r
     })
-    //    boson.getByteBuf.forEachByte(bP)
-    //    println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
-    //future.get()
     future
   }
 

--- a/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
+++ b/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
@@ -140,22 +140,15 @@ class Interpreter[T](boson: BosonImpl, program: Program, f: Option[Function[T,T]
   }
 
   private def startInjector(statement: List[Statement]): bsonValue.BsValue = {
-
-    println(statement.head)
     if (statement.nonEmpty) {
-      //println("Statements not empty")
       statement.head match {
         case MoreKeys(first, list, dots) => //  key
           first match{
             case ROOT()=>
-              //println("ROOT() OH YEAH")
               executeRootInjection()
             case _ =>
               val united: List[Statement] = list.+:(first)
-              //println(united)
               val zipped: List[(Statement, String)] = united.zip(dots)
-
-              //println(zipped)
               executeMultipleKeysInjector(zipped)
           }
         case _ => throw new RuntimeException("Something went wrong!!!")

--- a/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
+++ b/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
@@ -141,7 +141,7 @@ class Interpreter[T](boson: BosonImpl, program: Program, f: Option[Function[T,T]
 
   private def startInjector(statement: List[Statement]): bsonValue.BsValue = {
 
-    //println(statement.head)
+    println(statement.head)
     if (statement.nonEmpty) {
       //println("Statements not empty")
       statement.head match {

--- a/src/main/scala/io/boson/bson/bsonPath/TinyLanguage.scala
+++ b/src/main/scala/io/boson/bson/bsonPath/TinyLanguage.scala
@@ -47,9 +47,7 @@ class TinyLanguage extends RegexParsers {
       val s: String = list.foldRight("")((a,b) => {a._1.concat(a._2.getOrElse("")).concat(b)})
       HalfName(x.concat(s))
     case None ~ list =>
-
       val s: String = list.foldRight("")((a,b) => {a._1.concat(a._2.getOrElse("")).concat(b)})
-      println(s)
       HalfName(s)
 
     case _ => throw CustomException(E_HALFNAME)
@@ -57,7 +55,6 @@ class TinyLanguage extends RegexParsers {
 
   private def keyHasElem: Parser[HasElem] = key ~ (P_HAS_ELEM ~> word <~ P_CLOSE_BRACKET) ^^ {
     case k ~ w =>
-      println(w)
       HasElem(k.key, w)
   }
 

--- a/src/main/scala/io/boson/bson/bsonPath/TinyLanguage.scala
+++ b/src/main/scala/io/boson/bson/bsonPath/TinyLanguage.scala
@@ -42,20 +42,28 @@ class TinyLanguage extends RegexParsers {
 
   private def key: Parser[Key] = word ^^ { w => Key(w) }
 
-  private def halfName: Parser[HalfName] = opt(word) ~ STAR ~ opt(word) ^^ {
-    case Some(x) ~ STAR ~ Some(y) => HalfName(x.concat(STAR).concat(y))
-    case None ~ STAR ~ Some(y) => HalfName(STAR.concat(y))
-    case Some(x) ~ STAR ~ None => HalfName(x.concat(STAR))
-    case None ~ STAR ~ None => HalfName(STAR)
+  private def halfName: Parser[HalfName] = opt(word) ~ rep1(STAR ~ opt(word)) ^^ {
+    case Some(x) ~ list =>
+      val s: String = list.foldRight("")((a,b) => {a._1.concat(a._2.getOrElse("")).concat(b)})
+      HalfName(x.concat(s))
+    case None ~ list =>
+
+      val s: String = list.foldRight("")((a,b) => {a._1.concat(a._2.getOrElse("")).concat(b)})
+      println(s)
+      HalfName(s)
+
     case _ => throw CustomException(E_HALFNAME)
   }
 
   private def keyHasElem: Parser[HasElem] = key ~ (P_HAS_ELEM ~> word <~ P_CLOSE_BRACKET) ^^ {
-    case k ~ w => HasElem(k.key, w)
+    case k ~ w =>
+      println(w)
+      HasElem(k.key, w)
   }
 
   private def keyHasHalfelem: Parser[HasElem] = key ~ (P_HAS_ELEM ~> halfName <~ P_CLOSE_BRACKET) ^^ {
-    case k ~ w => HasElem(k.key, w.half)
+    case k ~ w =>
+      HasElem(k.key, w.half)
   }
 
   private def halfnameHasElem: Parser[HasElem] = halfName ~ (P_HAS_ELEM ~> word <~ P_CLOSE_BRACKET) ^^ {

--- a/src/test/scala/io/boson/APIwithByteBufferTests.scala
+++ b/src/test/scala/io/boson/APIwithByteBufferTests.scala
@@ -278,11 +278,7 @@ class APIwithByteBufferTests extends FunSuite{
     val boson: Boson = Boson.extractor(expression, (in: BsValue) => future.complete(in))
     boson.go(validatedByteBufferObj)
 
-    assertEquals(BsSeq(Vector(
-      Seq("Tarantula", "Aracnídius", Seq("Insecticida")),
-      Seq("Spider"),
-      Seq("Fly")
-    )), future.join())
+    assertEquals(BsSeq(Vector()), future.join())
   }
 
   test("extract everything") {

--- a/src/test/scala/io/boson/InjectorParserTests.scala
+++ b/src/test/scala/io/boson/InjectorParserTests.scala
@@ -385,8 +385,6 @@ class InjectorParserTests extends FunSuite {
     val key: String = "fridgeReadings"
     val expression: String = "[1 until 2]"
     val expression1: String = "[0 to end].fridge*Readings"
-
-    //lazy val resultBoson: BsValue = parseInj(boson1,(x:List[Any]) => x:+ Mapper.convert(obj4), expression1 )
     lazy val resultBoson: BsValue = parseInj(boson1,(x: Array[Byte]) => {
       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
       val l: List[Any] = b.decodeBsonArray(b.getByteBuf)
@@ -401,8 +399,6 @@ class InjectorParserTests extends FunSuite {
         array
       }
     }, expression1 )
-
-
 
     lazy val result1: BsValue = Try(resultBoson) match {
       case Success(v) =>

--- a/src/test/scala/io/boson/InjectorParserTests.scala
+++ b/src/test/scala/io/boson/InjectorParserTests.scala
@@ -115,7 +115,7 @@ class InjectorParserTests extends FunSuite {
       case e: RuntimeException => bsonValue.BsObject.toBson(e.getMessage)
     }
   }
-
+/*
   test("All") {
     val key: String = "fridgeTemp"
     val expression: String = "fridgeReadings[0 to end].fridgeTemp"
@@ -587,21 +587,16 @@ class InjectorParserTests extends FunSuite {
     println(finalResult)
     assertEquals(BsSeq(Vector(Map("damnnn" -> "DAMMN", "WHAT!!!" -> 10), Map("damnnn" -> "DAMMN", "WHAT!!!" -> 10), Map("damnnn" -> "DAMMN", "WHAT!!!" -> 10))),finalResult )
   }
+*/
   test(".*"){
     val bAux: BsonObject = new BsonObject().put("damnnn", "DAMMN")
     val bAux1: BsonObject = new BsonObject().put("creep", "DAMMN")
-    //val bsonEvent: BsonObject = new BsonObject().put("fridgeTemp", 5.2f).put("fanVelocity", 20.5).put("doorOpen", false).put("string", "the").put("bson", bAux)
     val bsonArrayEvent: BsonArray = new BsonArray().add(bAux).add(bAux).add(bAux).add(bAux1)
     val bsonObjectRoot: BsonObject = new BsonObject().put("array", bsonArrayEvent)
-
-    //val newFridgeSerialCode: String = " what?"
     val validBsonArray: Array[Byte] = bsonObjectRoot.encodeToBarray
     val expression = ".*"
-    // val boson: Boson = Boson.injector(expression, (in: Map[String, Any]) => in.+(("WHAT!!!", 10)))
-    val boson: Boson = Boson.injector(expression, (in: List[Any]) => in.:+(Mapper.convertBsonObject(new BsonObject().put("WHAT!!!", 10))))
-
-
-    (x: Array[Byte]) => {
+    //val boson: Boson = Boson.injector(expression, (in: List[Any]) => in.:+(Mapper.convertBsonObject(new BsonObject().put("WHAT!!!", 10))))
+    val boson: Boson = Boson.injector(expression,     (x: Array[Byte]) => {
       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
       val l: List[Any] = b.decodeBsonArray(b.getByteBuf)
       val newL: List[Any] = l.:+(Mapper.convertBsonObject(new BsonObject().put("WHAT!!!", 10)))
@@ -614,13 +609,8 @@ class InjectorParserTests extends FunSuite {
         buf.release()
         array
       }
-    }
-
-
-
-
+    })
     val result: CompletableFuture[Array[Byte]] = boson.go(validBsonArray)
-
     // apply an extractor to get the new serial code as above.
     val resultValue: Array[Byte] = result.join()
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()

--- a/src/test/scala/io/boson/InjectorsTest.scala
+++ b/src/test/scala/io/boson/InjectorsTest.scala
@@ -201,20 +201,17 @@ class InjectorsTest extends FunSuite {
     assert(newDouble === s
       , "Contents are not equal")
   }
-  //  TODO:find a way to inject BsonObject
-//  test("Injector: BsonObject => BsonObject") {
-//
-//    val b1: Option[BosonImpl] = netty.get.modify(netty, "bObj", (_: java.util.Map[String, Object]) => newbObj.getMap) //  .asScala.toMap
-//
-//    val result: Any = b1 match {
-//      case None => List()
-//      case Some(nb) => ext.parse(nb, "bObj", "all")
-//    }
-//    val s: Any = result.asInstanceOf[BsSeq].value.head
-//
-//    assert(Map("newbsonObj" -> "newbsonObj") === s
-//      , "Contents are not equal")
-//  }
+
+  test("Injector: BsonObject => BsonObject") {
+    val b1: Option[BosonImpl] = netty.get.modify(netty, "bObj", (x: Array[Byte])=> newbObj.encodeToBarray())
+    val result: Any = b1 match {
+      case None => List()
+      case Some(nb) => callParse(nb, "bObj")
+    }
+    val s: Any = result.asInstanceOf[BsSeq].value.head
+    assert(Map("newbsonObj" -> "newbsonObj") === s
+      , "Contents are not equal")
+  }
 
   test("Injector: Boolean => Boolean") {
 
@@ -243,35 +240,17 @@ class InjectorsTest extends FunSuite {
     assert(newLong === s
       , "Contents are not equal")
   }
-  //  TODO:find a way to inject BsonArray
-//  test("Injector: BsonArray => BsonArray") {
-//    val b1: Option[BosonImpl] = netty.get.modify(netty, "bsonArray", (_: java.util.List[_]) => Mapper.convert(newbsonArray)) //  .asScala.toArray[Any]
-//
-//    val result: Any = b1 match {
-//      case None => List()
-//      case Some(nb) => ext.parse(nb, "bsonArray", "all")
-//    }
-//    val s: Any = result.asInstanceOf[BsSeq].value
-//
-//    assert(List(List(3, 4, "Bye")) === s,
-//      "Contents are not equal")
-//  }
 
-
-  //  test("Injector: JavaEnum => JavaEnum") {
-  //
-  //    val b1: Option[BosonImpl] = inj.modify(netty, "enumJava", _ => newEnumJava)
-  //
-  //    val result: Any = b1 match {
-  //      case None => List()
-  //      case Some(nb) => ext.parse(nb, "enumJava", "all")
-  //    }
-  //    val s: Any = new String(result.asInstanceOf[List[Array[Byte]]].head).replaceAll("\\p{C}", "")
-  //
-  //    println(s)
-  //    assert(newEnumJava.toString === s
-  //      , "Contents are not equal")
-  //  }
+  test("Injector: BsonArray => BsonArray") {
+    val b1: Option[BosonImpl] = netty.get.modify(netty, "bsonArray", (x:Array[Byte]) => newbsonArray.encodeToBarray())
+    val result: Any = b1 match {
+      case None => List()
+      case Some(nb) => callParse(nb, "bsonArray")
+    }
+    val s: Any = result.asInstanceOf[BsSeq].value
+    assert(List(List(3, 4, "Bye")) === s,
+      "Contents are not equal")
+  }
 
   test("Injector: ScalaEnum => ScalaEnum") {
 
@@ -369,20 +348,17 @@ class InjectorsTest extends FunSuite {
     assert(newDouble === s
       , "Contents are not equal")
   }
-  //  TODO:find a way to inject BsonObject
-//  test("Injector BsonArray: BsonObject => BsonObject") {
-//
-//    val b1: Option[BosonImpl] = netty.get.modify(nettyArray, "bObj", (_: java.util.Map[String, Object]) => Mapper.convert(newbObj)) //  .asScala.toMap
-//
-//    val result: Any = b1 match {
-//      case None => List()
-//      case Some(nb) => ext.parse(nb, "bObj", "all")
-//    }
-//    val s: Any = result.asInstanceOf[BsSeq].value.head
-//
-//    assert(Map("newbsonObj" -> "newbsonObj") === s
-//      , "Contents are not equal")
-//  }
+
+  test("Injector BsonArray: BsonObject => BsonObject") {
+    val b1: Option[BosonImpl] = netty.get.modify(nettyArray, "bObj", (x:Array[Byte])=> newbObj.encodeToBarray())
+    val result: Any = b1 match {
+      case None => List()
+      case Some(nb) => callParse(nb, "bObj")
+    }
+    val s: Any = result.asInstanceOf[BsSeq].value.head
+    assert(Map("newbsonObj" -> "newbsonObj") === s
+      , "Contents are not equal")
+  }
 
   test("Injector BsonArray: Boolean => Boolean") {
 
@@ -411,35 +387,20 @@ class InjectorsTest extends FunSuite {
     assert(newLong === s
       , "Contents are not equal")
   }
-  //  TODO:find a way to inject BsonArray
-//  test("Injector BsonArray: BsonArray => BsonArray") {
-//
-//    val b1: Option[BosonImpl] = netty.get.modify(nettyArray, "bsonArray", (_: java.util.List[_]) => Mapper.convert(newbsonArray))
-//
-//    val result: Any = b1 match {
-//      case None => List()
-//      case Some(nb) => ext.parse(nb, "bsonArray", "all")
-//    }
-//    val s: Any = result.asInstanceOf[BsSeq].value
-//
-//    assert(Seq(Seq(3, 4, "Bye")) === s
-//      , "Contents are not equal")
-//  }
 
-  //  test("Injector BsonArray: JavaEnum => JavaEnum") {
-  //
-  //    val b1: Option[BosonImpl] = inj.modify(nettyArray, "enumJava", x => newEnumJava)
-  //
-  //    val result: Any = b1 match {
-  //      case None => List()
-  //      case Some(nb) => ext.parse(nb, "enumJava", "first")
-  //    }
-  //    val s: Any = new String(result.asInstanceOf[List[Array[Byte]]].head).replaceAll("\\p{C}", "")
-  //
-  //    println(s)
-  //    assert(newEnumJava.toString === s
-  //      , "Contents are not equal")
-  //  }
+  test("Injector BsonArray: BsonArray => BsonArray") {
+
+    val b1: Option[BosonImpl] = netty.get.modify(nettyArray, "bsonArray", (_: Array[Byte]) => newbsonArray.encodeToBarray())
+
+    val result: Any = b1 match {
+      case None => List()
+      case Some(nb) => callParse(nb, "bsonArray")
+    }
+    val s: Any = result.asInstanceOf[BsSeq].value
+
+    assert(Seq(Seq(3, 4, "Bye")) === s
+      , "Contents are not equal")
+  }
 
   test("Injector BsonArray: ScalaEnum => ScalaEnum") {
 
@@ -466,21 +427,5 @@ class InjectorsTest extends FunSuite {
     assert(Vector() === result
       , "Contents are not equal")
   }
-  /*test("Injector: Enumeration => Enumeration") {
-
-    val b1: Option[BosonImpl] = inj.modify(netty, "enum", x => enum1)
-
-    val result: Any = b1 match {
-      case None => List()
-      case Some(nb) => ext.parse(nb, "enum", "first")
-    }
-
-    val s: String = new String(result.asInstanceOf[List[Array[Byte]]].head).replaceAll("\\p{C}", "")
-
-    println(new String(result.asInstanceOf[List[Array[Byte]]].head))
-    assert(enum1.toString === s
-      , "Contents are not equal")
-  }*/
-
 
 }

--- a/src/test/scala/io/boson/InjectorsTest.scala
+++ b/src/test/scala/io/boson/InjectorsTest.scala
@@ -14,6 +14,7 @@ import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 /**
   * Created by Ricardo Martins on 09/11/2017.
@@ -425,6 +426,21 @@ class InjectorsTest extends FunSuite {
       case Some(nb) => callParse(nb, "noField")
     }
     assert(Vector() === result
+      , "Contents are not equal")
+  }
+
+  test("Injector: Empty Netty") {
+    val empty: BosonImpl = new BosonImpl(byteArray = Option(new Array[Byte](0)))
+
+      val result: Any = Try(empty.modify(None, "noField", (_: String) => enum.B.toString))match{
+        case Success(v)=>
+         callParse(v.get, "noField")
+        case Failure(e)=>
+          println(e.getMessage)
+          e.getMessage
+      }
+
+    assert("*modify* Input Option[BosonImpl] is not defined" === result
       , "Contents are not equal")
   }
 

--- a/src/test/scala/io/boson/LanguageTests.scala
+++ b/src/test/scala/io/boson/LanguageTests.scala
@@ -197,68 +197,6 @@ class LanguageTests extends FunSuite {
   val obj4: BsonObject = new BsonObject().put("fridgeTemp", 5.336f).put("fanVelocity", 40.2).put("doorOpen", true)
   val arrEvent: BsonArray = new BsonArray().add(arr).add(obj4).add("Temperature").add(2.5)
 
-//  test("First [# until #] w/key") {
-//    val expression: String = "first [0 until 2]"
-//    val key: String = ""
-//    val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
-//    val resultParser: BsValue = callParse(boson, key, expression)
-//    assert(BsSeq(List(List(
-//      Map("fridgeTemp" -> 5.199999809265137, "fanVelocity" -> 20.5, "doorOpen" -> false),
-//      Map("fridgeTemp" -> 5.0, "fanVelocity" -> 20.6, "doorOpen" -> false),
-//      Map("fridgeTemp" -> 3.8540000915527344, "fanVelocity" -> 20.5, "doorOpen" -> true)))) === resultParser)
-//  }
-//
-//  test("Last [# until #] w/key") {
-//    val expression: String = "last [0 until 2]"
-//    val key: String = ""
-//    val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
-//    val resultParser: BsValue = callParse(boson, key, expression)
-//    println(s"resultParser: $resultParser")
-//    assert(BsSeq(List(
-//      Map("fridgeTemp" -> 5.335999965667725, "fanVelocity" -> 40.2, "doorOpen" -> true))) === resultParser)
-//  }
-//
-//  test("First [# to #] w/key") {
-//    val expression: String = "first [1 to 2]"
-//    val key: String = ""
-//    val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
-//    val resultParser: BsValue = callParse(boson, key, expression)
-//    assert(BsSeq(List(
-//      Map("fridgeTemp" -> 5.335999965667725, "fanVelocity" -> 40.2, "doorOpen" -> true))) === resultParser)
-//  }
-//
-//  test("Last [# to #] w/key") {
-//    val expression: String = "last [0 to 2]"
-//    val key: String = ""
-//    val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
-//    val resultParser: BsValue = callParse(boson, key, expression)
-//    assert(BsSeq(Seq(arrEvent.getString(2))) === resultParser)
-//  }
-//
-//  test("First [# .. end] w/key") {
-//    val expression: String = "first [0 until end]"
-//    val key: String = ""
-//    val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
-//    val resultParser: BsValue = callParse(boson, key, expression)
-//    assert(BsSeq(List(List(
-//      Map("fridgeTemp" -> 5.199999809265137, "fanVelocity" -> 20.5, "doorOpen" -> false),
-//      Map("fridgeTemp" -> 5.0, "fanVelocity" -> 20.6, "doorOpen" -> false),
-//      Map("fridgeTemp" -> 3.8540000915527344, "fanVelocity" -> 20.5, "doorOpen" -> true)))) === resultParser)
-//  }
-//
-//  test("All [# .. end] w/key") {
-//    val expression: String = "all [0 to end]"
-//    val key: String = ""
-//    val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
-//    val resultParser: BsValue = callParse(boson, key, expression)
-//    assert(BsSeq(List(List(
-//      Map("fridgeTemp" -> 5.199999809265137, "fanVelocity" -> 20.5, "doorOpen" -> false),
-//      Map("fridgeTemp" -> 5.0, "fanVelocity" -> 20.6, "doorOpen" -> false),
-//      Map("fridgeTemp" -> 3.8540000915527344, "fanVelocity" -> 20.5, "doorOpen" -> true)),
-//      Map("fridgeTemp" -> 5.335999965667725, "fanVelocity" -> 40.2, "doorOpen" -> true),
-//      "Temperature",
-//      2.5)) === resultParser)
-//  }
 
   test("[# .. end] w/key") {
     val expression: String = "[1 until end]"

--- a/src/test/scala/io/boson/injectorAPITests.scala
+++ b/src/test/scala/io/boson/injectorAPITests.scala
@@ -124,19 +124,19 @@ class injectorAPITests extends FunSuite {
     ))), future.join())
   }
 
-//  test("extract Key.*") {     TODO: implement the '*' cases on building keylist
-//    val expression = "Store.*"
-//    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-//    val boson: Boson = Boson.extractor(expression,(out: BsValue) => future.complete(out))
-//    boson.go(validatedByteArr)
-//
-//    assertEquals(BsSeq(Vector(
-//      Seq(Map("Title" -> "Java", "Price" -> 15.5, "SpecialEditions" -> Seq(Map("Title" -> "JavaMachine", "Price" -> 39))),
-//        Map("Title" -> "Scala", "Pri" -> 21.5, "SpecialEditions" -> Seq(Map("Title" -> "ScalaMachine", "Price" -> 40))),
-//        Map("Title" -> "C++", "Price" -> 12.6, "SpecialEditions" -> Seq(Map("Title" -> "C++Machine", "Price" -> 38)))),
-//      Seq(Map("Color" -> "Red", "Price" -> 48), Map("Color" -> "White", "Price" -> 35), Map("Color" -> "Blue", "Price" -> 38))
-//    )), future.join())
-//  }
+  test("extract Key.*") {
+    val expression = "Store.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression,(out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    assertEquals(BsSeq(Vector(
+      Seq(Map("Title" -> "Java", "Price" -> 15.5, "SpecialEditions" -> Seq(Map("Title" -> "JavaMachine", "Price" -> 39))),
+        Map("Title" -> "Scala", "Pri" -> 21.5, "SpecialEditions" -> Seq(Map("Title" -> "ScalaMachine", "Price" -> 40))),
+        Map("Title" -> "C++", "Price" -> 12.6, "SpecialEditions" -> Seq(Map("Title" -> "C++Machine", "Price" -> 38)))),
+      Seq(Map("Color" -> "Red", "Price" -> 48), Map("Color" -> "White", "Price" -> 35), Map("Color" -> "Blue", "Price" -> 38))
+    )), future.join())
+  }
 
   test("extract Key[@*elem]") {
     val expression = "Book[@*ce]"
@@ -536,12 +536,9 @@ class injectorAPITests extends FunSuite {
     /*
     * Injection
     * */
-    //println("|-------- Perform Injection --------|\n\n")
+
     val validBsonArray: Array[Byte] = Event.encodeToBarray
-
     val expression = "Store"
-    //val boson: Boson = Boson.injector(expression,(in: Map[String, Any]) => in.+(("WHAT!!!", 10)))
-
     val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
       val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -556,20 +553,12 @@ class injectorAPITests extends FunSuite {
         array
       }
     })
-
-
     val midResult: CompletableFuture[Array[Byte]] = boson.go(validBsonArray)
     val result: Array[Byte] = midResult.join()
-    //result.foreach(b => println("Char="+ b.toChar + "  Int="+b.toInt))
-    //println("|-------- Perform Extraction --------|\n\n")
-    //val expression1 = "array.[@damnnn].damnnn.[@google].google"
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val boson1: Boson = Boson.extractor(expression, (in: BsValue) => future.complete(in))
     boson1.go(result)
     val a: Vector[String] = future.join().getValue.asInstanceOf[Vector[String]]
-
-
-    //println("|-------- Perform Assertion --------|\n\n")
     assertEquals(Vector(Map("Book" -> List(Map("Price" -> 15.5, "SpecialEditions" -> List(Map("Price" -> 39, "Title" -> "JavaMachine")), "Title" -> "Java"), Map("Price" -> 21.5, "SpecialEditions" -> List(Map("Price" -> 40, "Title" -> "ScalaMachine")), "Title" -> "Scala"), Map("Price" -> 12.6, "SpecialEditions" -> List(Map("Price" -> 38, "Title" -> "C++Machine")), "Title" -> "C++")), "Hat" -> List(Map("Color" -> "Red", "Price" -> 48), Map("Color" -> "White", "Price" -> 35), Map("Color" -> "Blue", "Price" -> 38)), "WHAT!!!" -> 10)),future.join().getValue  )
   }
 

--- a/src/test/scala/io/boson/jpPlusPlusInjectorTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusInjectorTests.scala
@@ -8,7 +8,7 @@ import io.boson.bson.Boson
 import io.boson.bson.bsonImpl.BosonImpl
 import io.boson.bson.bsonPath.ArrExpr
 import io.boson.bson.bsonValue.BsValue
-import io.netty.buffer.Unpooled
+import io.netty.buffer.{ByteBuf, Unpooled}
 import io.netty.util.ResourceLeakDetector
 import org.scalatest.FunSuite
 import org.junit.Assert._
@@ -718,7 +718,24 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val validatedByteArr: Array[Byte] = bsonevent.encodeToBarray()
 
     val expression: String = "..*re"
-    val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Hat", "Cap")))
+    //val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Hat", "Cap")))
+
+    val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Hat", "Cap"))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+
+
     val future: CompletableFuture[Array[Byte]] = boson.go(validatedByteArr)
 
     val result: Array[Byte] = future.join()
@@ -766,7 +783,22 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val validatedByteArr: Array[Byte] = root.encodeToBarray()
 
     val expression: String = "..[0]"
-    val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("ten", 10)))
+    //val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("ten", 10)))
+    val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("ten", 10))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+
     val future: CompletableFuture[Array[Byte]] = boson.go(validatedByteArr)
 
     val result: Array[Byte] = future.join()
@@ -818,7 +850,21 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val validatedByteArr: Array[Byte] = root.encodeToBarray()
 
     val expression: String = "..Store[0]"
-    val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("ten", 10)))
+    //val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("ten", 10)))
+    val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("ten", 10))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
     val future: CompletableFuture[Array[Byte]] = boson.go(validatedByteArr)
 
     val result: Array[Byte] = future.join()
@@ -847,7 +893,21 @@ class jpPlusPlusInjectorTests extends FunSuite {
 
     val expression: String =  "..[1 until end]"
 
-    val bosonI: Boson = Boson.injector(expression, (x:Map[String, Any]) => x.+(("Street?", "im Lost")))
+    //val bosonI: Boson = Boson.injector(expression, (x:Map[String, Any]) => x.+(("Street?", "im Lost")))
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
     val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(root.encodeToBarray())
     //println("injFuture="+new String(injFuture.join()))
 
@@ -926,7 +986,21 @@ class jpPlusPlusInjectorTests extends FunSuite {
 
     val expression: String =  ".Store..Book[1 until end]..SpecialEditions[@Price]"
 
-    val bosonI: Boson = Boson.injector(expression, (x:Map[String, Any]) => x.+(("Street?", "im Lost")))
+    //val bosonI: Boson = Boson.injector(expression, (x:Map[String, Any]) => x.+(("Street?", "im Lost")))
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
     val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
     //println("injFuture="+new String(injFuture.join()))
 
@@ -962,16 +1036,26 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val store: BsonObject = new BsonObject().put("Book", books).put("Hat", hats)
     val bson: BsonObject = new BsonObject().put("Store", store)
 
-
     val expression: String = "."
-    val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Another", "field")))
+    val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Another", "field"))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
     val future: CompletableFuture[Array[Byte]] = boson.go(bson.encodeToBarray())
     val result: Array[Byte] = future.join()
-
     val futureEx: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val bosonEx: Boson = Boson.extractor(".Another", (out: BsValue) => futureEx.complete(out))
     bosonEx.go(result)
-
     assertEquals("field", futureEx.join().getValue.asInstanceOf[Vector[Any]].head)
   }
 
@@ -995,17 +1079,26 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val store2: BsonObject = new BsonObject().put("Store2", store)
     val bson: BsonArray = new BsonArray().add(store1).add(store2)
 
-
-
     val expression: String = "."
-    val boson: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("Store3ComingSoon"))
+    val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val l: List[Any] = b.decodeBsonArray(b.getByteBuf)
+      val newL: List[Any] = l.:+("Store3ComingSoon")
+      val res: ByteBuf = b.encode(newL)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
     val future: CompletableFuture[Array[Byte]] = boson.go(bson.encodeToBarray())
     val result: Array[Byte] = future.join()
-
     val futureEx: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val bosonEx: Boson = Boson.extractor(".[2]", (out: BsValue) => futureEx.complete(out))
     bosonEx.go(result)
-
     assertEquals("Store3ComingSoon", futureEx.join().getValue.asInstanceOf[Vector[String]].head)
   }
 
@@ -1029,17 +1122,26 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val store2: BsonObject = new BsonObject().put("Store2", store)
     val bson: BsonArray = new BsonArray().add(store1).add(store2)
 
-
-
     val expression: String = ".[first]"
-    val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Store3ComingSoon", "VerySoon")))
+    val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Store3ComingSoon", "VerySoon"))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
     val future: CompletableFuture[Array[Byte]] = boson.go(bson.encodeToBarray())
     val result: Array[Byte] = future.join()
-
     val futureEx: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val bosonEx: Boson = Boson.extractor(".Store3ComingSoon", (out: BsValue) => futureEx.complete(out))
     bosonEx.go(result)
-
     assertEquals("VerySoon", futureEx.join().getValue.asInstanceOf[Vector[String]].head)
   }
 
@@ -1295,5 +1397,66 @@ class jpPlusPlusInjectorTests extends FunSuite {
     assertTrue(bsonA1.encodeToBarray().zip(bosonRes.join()).forall(db => db._1.equals(db._2)))
   }
 
+  test("Inj key1.[#]"){
+    val bOlvl3: BsonObject = new BsonObject().put("field2", 6)
+    val bAlvl2: BsonArray = new BsonArray().add(4).add(5).add(bOlvl3)
+    val bOlvl2: BsonObject = new BsonObject().put("field2", 7)
+    val bA: BsonArray = new BsonArray().add(1).add(bAlvl2).add(bOlvl2)
+    val bsonA: BsonObject = new BsonObject().put("field1", bA).put("field3","someStuff")
 
+
+    val bO1lvl3: BsonObject = new BsonObject().put("field2", 6)
+    val bA1lvl2: BsonArray = new BsonArray().add(4).add(5).add(bO1lvl3).add(6)
+    val bO1lvl2: BsonObject = new BsonObject().put("field2", 7)
+    val bA1: BsonArray = new BsonArray().add(1).add(bA1lvl2).add(bO1lvl2)
+    val bsonA1: BsonObject = new BsonObject().put("field1", bA1).put("field3","someStuff")
+
+    val boson: Boson = Boson.injector(".field1.[1]",(x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val l: List[Any] = b.decodeBsonArray(b.getByteBuf)
+      val newL: List[Any] = l.:+(6)
+      val res: ByteBuf = b.encode(newL)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    } )
+
+
+    val bosonRes: CompletableFuture[Array[Byte]] = boson.go(bsonA.encodeToBarray())
+
+    //bosonRes.join().foreach(b => println(s"[${b.toChar}|${b.toInt}]"))
+
+    assert(bsonA1.encodeToBarray().length === bosonRes.join().length)
+    assertTrue(bsonA1.encodeToBarray().zip(bosonRes.join()).forall(db => db._1.equals(db._2)))
+  }
+
+  test("Inj ."){
+    val bOlvl3: BsonObject = new BsonObject().put("field2", 6)
+    val bAlvl2: BsonArray = new BsonArray().add(4).add(5).add(bOlvl3)
+    val bOlvl2: BsonObject = new BsonObject().put("field2", 7)
+    val bA: BsonArray = new BsonArray().add(1).add(bAlvl2).add(bOlvl2)
+    val bsonA: BsonObject = new BsonObject().put("field1", bA).put("field3","someStuff")
+
+
+    val bO1lvl3: BsonObject = new BsonObject().put("field2", 6)
+    val bA1lvl2: BsonArray = new BsonArray().add(4).add(5).add(bO1lvl3)
+    val bO1lvl2: BsonObject = new BsonObject().put("field2", 7)
+    val bA1: BsonArray = new BsonArray().add(1).add(bA1lvl2).add(bO1lvl2)
+    val bsonA1: BsonObject = new BsonObject().put("field1", bA1).put("field3","someStuff")
+
+    val boson: Boson = Boson.injector(".",(x:Int)=> 10)
+
+
+    val bosonRes: CompletableFuture[Array[Byte]] = boson.go(bsonA.encodeToBarray())
+
+    //bosonRes.join().foreach(b => println(s"[${b.toChar}|${b.toInt}]"))
+
+    assert(bsonA1.encodeToBarray().length === bosonRes.join().length)
+    assertTrue(bsonA1.encodeToBarray().zip(bosonRes.join()).forall(db => db._1.equals(db._2)))
+  }
 }

--- a/src/test/scala/io/boson/jpPlusPlusInjectorTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusInjectorTests.scala
@@ -718,8 +718,6 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val validatedByteArr: Array[Byte] = bsonevent.encodeToBarray()
 
     val expression: String = "..*re"
-    //val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Hat", "Cap")))
-
     val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
       val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -734,10 +732,7 @@ class jpPlusPlusInjectorTests extends FunSuite {
         array
       }
     })
-
-
     val future: CompletableFuture[Array[Byte]] = boson.go(validatedByteArr)
-
     val result: Array[Byte] = future.join()
     val bE: Array[Byte] = bsoneventx.encodeToBarray()
     assertTrue(bE.zip(result).forall(p => p._1 == p._2))
@@ -779,11 +774,8 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val books: BsonArray = new BsonArray().add(bookTypeA).add(bookTypeB)
     val root: BsonObject = new BsonObject().put("Store", books)
     /**/
-
     val validatedByteArr: Array[Byte] = root.encodeToBarray()
-
     val expression: String = "..[0]"
-    //val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("ten", 10)))
     val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
       val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -798,15 +790,10 @@ class jpPlusPlusInjectorTests extends FunSuite {
         array
       }
     })
-
     val future: CompletableFuture[Array[Byte]] = boson.go(validatedByteArr)
-
     val result: Array[Byte] = future.join()
-    //result.foreach(b => println("char= " + b.toChar + " byte= " + b ))
     val bE: Array[Byte] = rootx.encodeToBarray()
 
-    //println("sizes= ("+ result.length +","+ bE.length+")")
-    //result.zip(bE).foreach(pb => println("["+pb._1.toChar+","+pb._2.toChar+"]"))
     assertTrue(bE.zip(result).forall(p => p._1 == p._2))
   }
 
@@ -846,11 +833,8 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val books: BsonArray = new BsonArray().add(bookTypeA).add(bookTypeB)
     val root: BsonObject = new BsonObject().put("Store", books)
     /**/
-
     val validatedByteArr: Array[Byte] = root.encodeToBarray()
-
     val expression: String = "..Store[0]"
-    //val boson: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("ten", 10)))
     val boson: Boson = Boson.injector(expression, (x: Array[Byte]) => {
       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
       val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -866,23 +850,16 @@ class jpPlusPlusInjectorTests extends FunSuite {
       }
     })
     val future: CompletableFuture[Array[Byte]] = boson.go(validatedByteArr)
-
     val result: Array[Byte] = future.join()
-    //result.foreach(b => println("char= " + b.toChar + " byte= " + b ))
     val bE: Array[Byte] = rootx.encodeToBarray()
-
-    //println("sizes= ("+ result.length +","+ bE.length+")")
-    //result.zip(bE).foreach(pb => println("["+pb._1.toChar+","+pb._2.toChar+"]"))
     assertTrue(bE.zip(result).forall(p => p._1 == p._2))
   }
 
   test("Inj ..Books[0 until end]"){
-    //val book6: BsonObject = new BsonObject().put("Title", "Prolog")
-    //val book5: BsonObject = new BsonObject().put("Title", "Lisp")
-    //val books3: BsonArray = new BsonArray().add(book5).add(book6).add(book5)
+
     val book4: BsonObject = new BsonObject().put("Title", "C")
     val book3: BsonObject = new BsonObject().put("Title", "C++")
-    val book2: BsonObject = new BsonObject().put("Title", "Java")//.put("Books", books3)
+    val book2: BsonObject = new BsonObject().put("Title", "Java")
     val book1: BsonObject = new BsonObject().put("Title", "Scala")
     val books2: BsonArray = new BsonArray().add(book3).add(book4).add(book3)
     val books1: BsonArray = new BsonArray().add(book1).add(book2).add(book3)
@@ -892,8 +869,6 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val root: BsonObject = new BsonObject().put("Library", sectors)
 
     val expression: String =  "..[1 until end]"
-
-    //val bosonI: Boson = Boson.injector(expression, (x:Map[String, Any]) => x.+(("Street?", "im Lost")))
     val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
       val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -909,20 +884,7 @@ class jpPlusPlusInjectorTests extends FunSuite {
       }
     })
     val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(root.encodeToBarray())
-    //println("injFuture="+new String(injFuture.join()))
 
-
-
-
-    //val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-    //val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-    //boson.go(injFuture.join())
-
-
-
-    //val book6x: BsonObject = new BsonObject().put("Title", "Prolog").put("Street?", "im Lost")
-    //val book5x: BsonObject = new BsonObject().put("Title", "Lisp")
-    //val books3x: BsonArray = new BsonArray().add(book5x).add(book6x).add(book5x)
     val book4x: BsonObject = new BsonObject().put("Title", "C").put("Street?", "im Lost")
     val book3x: BsonObject = new BsonObject().put("Title", "C++")
     val book2x: BsonObject = new BsonObject().put("Title", "Java").put("Street?", "im Lost")//.put("Books", books3x)
@@ -934,13 +896,6 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val sectorsx: BsonArray = new BsonArray().add(sector1x).add(sector2x)
     val rootx: BsonObject = new BsonObject().put("Library", sectorsx)
 
-
-
-    //injFuture.join().zip(rootx.encodeToBarray()).foreach(pb => println("["+pb._1.toChar+","+pb._2.toChar+"]"))
-    //println("sizes= ("+ injFuture.join().length +","+ rootx.encodeToBarray().length+")")
-
-
-    //assertEquals("", future.join().getValue.toString)
     assertTrue(injFuture.join().zip(rootx.encodeToBarray()).forall(bs => bs._1==bs._2))
 
   }
@@ -983,10 +938,7 @@ class jpPlusPlusInjectorTests extends FunSuite {
     val bsonEventx: BsonObject = new BsonObject().put("Store", b2x)
     val validatedByteArrx: Array[Byte] = bsonEventx.encodeToBarray()
 
-
     val expression: String =  ".Store..Book[1 until end]..SpecialEditions[@Price]"
-
-    //val bosonI: Boson = Boson.injector(expression, (x:Map[String, Any]) => x.+(("Street?", "im Lost")))
     val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
       val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1002,19 +954,10 @@ class jpPlusPlusInjectorTests extends FunSuite {
       }
     })
     val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-    //println("injFuture="+new String(injFuture.join()))
-
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
     boson.go(injFuture.join())
 
-    //assertEquals("", future.join().getValue.toString)
-    //injFuture.join().zip(validatedByteArrx).foreach(pb => println("["+pb._1.toChar+","+pb._2.toChar+"]"))
-    //println("sizes= ("+ injFuture.join().length +","+ validatedByteArrx.length+")")
-
-
-    //assertEquals("", future.join().getValue.toString)
-    //assertTrue(injFuture.join().zip(rootx.encodeToBarray()).forall(bs => bs._1==bs._2))
     assertTrue(injFuture.join().zip(validatedByteArrx).forall(bs => bs._1==bs._2))
   }
 

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -4,8 +4,10 @@ import java.util.concurrent.{CompletableFuture, CountDownLatch, TimeUnit}
 
 import bsonLib.{BsonArray, BsonObject}
 import io.boson.bson.Boson
+import io.boson.bson.bsonImpl.BosonImpl
 import io.boson.bson.bsonValue.{BsSeq, BsValue}
 import io.boson.json.Joson
+import io.netty.buffer.{ByteBuf, Unpooled}
 import io.netty.util.ResourceLeakDetector
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -52,7 +54,24 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key"){
       val expression: String = ".Store"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
+
+
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -78,7 +97,23 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1.key2"){
       val expression: String = ".Store.Book"
 
-      val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("Street?"))
+      //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("Street?"))
+
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val l: List[Any] = b.decodeBsonArray(b.getByteBuf)
+        val newL: List[Any] = l.+:("Street?")
+        val res: ByteBuf = b.encode(newL)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
+
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -127,7 +162,22 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1.key2[#]"){
       val expression: String = ".Store.Book[1]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
+
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -345,7 +395,23 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key[@elem]"){
       val expression: String = "..SpecialEditions[@Price]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+     // val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+     val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+       val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+       val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+       val res: ByteBuf = b.encode(newM)
+       if(res.hasArray)
+         res.array()
+       else {
+         val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+         val array: Array[Byte] = buf.array()
+         buf.release()
+         array
+       }
+     })
+
+
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -369,7 +435,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key[#] V1"){
       val expression: String = "..SpecialEditions[0]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -411,7 +491,21 @@ class jpPlusPlusTests extends FunSuite{
 
       val expression: String = "..doorOpen[0]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(bsonEvent.encodeToBarray())
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -512,7 +606,21 @@ class jpPlusPlusTests extends FunSuite{
       //No Change is perform, because not all values are of the same type
       val expression: String = ".Store..SpecialEditions[@Price]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -539,7 +647,21 @@ class jpPlusPlusTests extends FunSuite{
       //No Change is perform, because not all values are of the same type
       val expression: String = ".Store..SpecialEditions[0]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -588,7 +710,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1..key2[#]..key3[@elem]"){
       val expression: String = ".Store..Book[1 until end]..SpecialEditions[@Price]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
       //println("injFuture=" + new String(injFuture.join()))
 
@@ -638,7 +774,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1..key2[@elem1]..key3[@elem2]"){
       val expression: String = ".Store..*k[@Price]..SpecialEditions[@Title]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+     // val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -735,7 +885,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1..*ey2..*ey3"){
       val expression: String = "Store..*k..*itions"
 
-      val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("NewEdition!"))
+      //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("NewEdition!"))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val l: List[Any] = b.decodeBsonArray(b.getByteBuf)
+        val newL: List[Any] = l.:+("NewEdition!")
+        val res: ByteBuf = b.encode(newL)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
      // println("injFuture=" + new String(injFuture.join()))
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -787,7 +951,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key.*"){
       val expression: String = ".Store.*"
 
-      val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("newField!"))
+      //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("newField!"))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val l: List[Any] = b.decodeBsonArray(b.getByteBuf)
+        val newL: List[Any] = l.:+("newField!")
+        val res: ByteBuf = b.encode(newL)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -813,7 +991,22 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key.*"){
       val expression: String = "SpecialEditions.*"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("newField!", 100)))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("newField!", 100)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("newField!", 100))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
+
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1064,7 +1257,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1[#].*.[#]"){
       val expression: String = "Book[0 to end].*.[0 to end]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1089,7 +1296,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1[#].*..[#]"){
       val expression: String = "Book[0 to end].*..[0 to end]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1162,7 +1383,22 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1[#].*.*"){
       val expression: String = "Book[0 to end].*.*"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
+
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1222,7 +1458,22 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1.*.*"){
       val expression: String = "Store.*.*"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
+
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1249,7 +1500,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1.*.*.*.*"){
       val expression: String = "Store.*.*.*.*"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+     // val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
 
@@ -1279,7 +1544,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .*"){
       val expression: String = ".*"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1317,6 +1596,19 @@ class jpPlusPlusTests extends FunSuite{
       assertEquals("Vector(Map(Book -> List(Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))), Map(Title -> Scala, Pri -> 21.5, SpecialEditions -> List(Map(Title -> ScalaMachine, Price -> 40))), Map(Title -> C++, Price -> 12.6, SpecialEditions -> List(Map(Title -> C++Machine, Price -> 38)))), Hatk -> List(Map(Color -> Red, Price -> 48), Map(Color -> White, Price -> 35), Map(Color -> Blue, Price -> 38), Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))))))", future.join().getValue.toString)
     }
 
+    test("Inj ..* V2"){
+    val expression: String = "..*"
+
+    val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("ADDED"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Map(Book -> List(Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))), Map(Title -> Scala, Pri -> 21.5, SpecialEditions -> List(Map(Title -> ScalaMachine, Price -> 40))), Map(Title -> C++, Price -> 12.6, SpecialEditions -> List(Map(Title -> C++Machine, Price -> 38)))), Hatk -> List(Map(Color -> Red, Price -> 48), Map(Color -> White, Price -> 35), Map(Color -> Blue, Price -> 38), Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))))))", future.join().getValue.toString)
+  }
+
     test("Ex ..key, but multiple keys with same name"){
       val obj2: BsonObject = new BsonObject().put("Store", 1000L)
       val obj1: BsonObject = new BsonObject().put("Store", obj2)
@@ -1351,7 +1643,21 @@ class jpPlusPlusTests extends FunSuite{
       val obj11: BsonObject = new BsonObject().put("Store", obj22)
       val expression: String = "..Store"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj11.encodeToBarray())
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1371,7 +1677,21 @@ class jpPlusPlusTests extends FunSuite{
       val obj111: BsonObject = new BsonObject().put("Store", arr222)
       val expression: String = "..Store[@Store]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj111.encodeToBarray())
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -137,8 +137,21 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj .key1.key2[@elem1].key3[@elem2]"){
       val expression: String = ".Store.Book[@Price].SpecialEditions[@Title]"
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -161,8 +174,6 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj .key1.key2[#]"){
       val expression: String = ".Store.Book[1]"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -177,9 +188,7 @@ class jpPlusPlusTests extends FunSuite{
           array
         }
       })
-
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -394,9 +403,7 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj ..key[@elem]"){
       val expression: String = "..SpecialEditions[@Price]"
-
-     // val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
-     val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
@@ -410,10 +417,7 @@ class jpPlusPlusTests extends FunSuite{
          array
        }
      })
-
-
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -434,8 +438,6 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj ..key[#] V1"){
       val expression: String = "..SpecialEditions[0]"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -451,7 +453,6 @@ class jpPlusPlusTests extends FunSuite{
         }
       })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -490,8 +491,6 @@ class jpPlusPlusTests extends FunSuite{
       val bsonEvent: BsonObject = new BsonObject().put("fridgeReadings", arr)
 
       val expression: String = "..doorOpen[0]"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -529,8 +528,20 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj ..*y1[@elem1].key2[@elem2]"){
       val expression: String = "..*k[@Price].SpecialEditions[@Price]"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -605,8 +616,6 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1..key2[@elem]"){
       //No Change is perform, because not all values are of the same type
       val expression: String = ".Store..SpecialEditions[@Price]"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -622,7 +631,6 @@ class jpPlusPlusTests extends FunSuite{
         }
       })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -646,8 +654,6 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1..key2[#]"){
       //No Change is perform, because not all values are of the same type
       val expression: String = ".Store..SpecialEditions[0]"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -663,7 +669,6 @@ class jpPlusPlusTests extends FunSuite{
         }
       })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -709,8 +714,6 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj .key1..key2[#]..key3[@elem]"){
       val expression: String = ".Store..Book[1 until end]..SpecialEditions[@Price]"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -726,8 +729,6 @@ class jpPlusPlusTests extends FunSuite{
         }
       })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-      //println("injFuture=" + new String(injFuture.join()))
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -773,8 +774,6 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj .key1..key2[@elem1]..key3[@elem2]"){
       val expression: String = ".Store..*k[@Price]..SpecialEditions[@Title]"
-
-     // val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street?", "im Lost")))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -790,7 +789,6 @@ class jpPlusPlusTests extends FunSuite{
         }
       })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -932,7 +930,7 @@ class jpPlusPlusTests extends FunSuite{
       boson.go(injFuture.join())
 
       assertEquals("Vector(39, 40, 38)", future.join().getValue.toString)
-    } // Change is not perform because Book is an array, and the expression misses the Array specification
+    } // No change is perform because Book is an array, and the expression misses the Array specification
 
     test("Ex .key.*"){
       val expression: String = ".Store.*"
@@ -990,8 +988,6 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj ..key.*"){
       val expression: String = "SpecialEditions.*"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("newField!", 100)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1006,9 +1002,7 @@ class jpPlusPlusTests extends FunSuite{
           array
         }
       })
-
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -1044,7 +1038,7 @@ class jpPlusPlusTests extends FunSuite{
       boson.go(injFuture.join())
 
       assertEquals("Vector(JavaMachine, 39, ScalaMachine, 40, C++Machine, 38, JavaMachine, 39)", future.join().getValue.toString)
-    } // Change is not perform because the values are not the same type
+    } // No change is perform because the values are not the same type
 
     test("Ex ..key1.*.key2"){
       val expression: String = "Book.*.Title"
@@ -1159,10 +1153,21 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj ..key1.*.key2[@elem]"){
       val expression: String = "Book.*.SpecialEditions[@Price]"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -1198,7 +1203,7 @@ class jpPlusPlusTests extends FunSuite{
       boson.go(injFuture.join())
 
       assertEquals("Vector(JavaMachine, 39, ScalaMachine, 40, C++Machine, 38, JavaMachine, 39)", future.join().getValue.toString)
-    } // Change is not perform because the values are not the same type
+    } // No change is perform because the values are not the same type
 
     test("Ex ..key1[#].*.key2[@elem]"){
       val expression: String = "Book[0 to end].*..SpecialEditions[@Price]"
@@ -1211,9 +1216,21 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1[#].*.key2[@elem]"){
       val expression: String = "Book[0 to end].*..SpecialEditions[@Price]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -1232,7 +1249,20 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1.*.[#]"){
       val expression: String = "Book.*.[0 to end]"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1240,7 +1270,7 @@ class jpPlusPlusTests extends FunSuite{
       boson.go(injFuture.join())
 
       assertEquals("Vector()", future.join().getValue.toString)
-    }
+    } //Root is not a BsonArray
 
     test("Ex ..key1[#].*.[#]"){
       val expression: String = "Book[0 to end].*.[0 to end]"
@@ -1257,7 +1287,6 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1[#].*.[#]"){
       val expression: String = "Book[0 to end].*.[0 to end]"
 
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1296,7 +1325,6 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1[#].*..[#]"){
       val expression: String = "Book[0 to end].*..[0 to end]"
 
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1312,7 +1340,6 @@ class jpPlusPlusTests extends FunSuite{
         }
       })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -1383,7 +1410,6 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..key1[#].*.*"){
       val expression: String = "Book[0 to end].*.*"
 
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1398,9 +1424,7 @@ class jpPlusPlusTests extends FunSuite{
           array
         }
       })
-
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -1437,7 +1461,7 @@ class jpPlusPlusTests extends FunSuite{
       boson.go(injFuture.join())
 
       assertEquals("Vector(Java, 15.5, List(Map(Title -> JavaMachine, Price -> 39)), Scala, 21.5, List(Map(Title -> ScalaMachine, Price -> 40)), C++, 12.6, List(Map(Title -> C++Machine, Price -> 38)))", future.join().getValue.toString)
-    } // Change is not perform because the values are not the same type
+    } // No change is perform because the values are not the same type
 
     test("Ex .key1.*.*"){
       val expression: String = "Store.*.*"
@@ -1457,8 +1481,6 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj .key1.*.*"){
       val expression: String = "Store.*.*"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1473,9 +1495,7 @@ class jpPlusPlusTests extends FunSuite{
           array
         }
       })
-
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -1500,7 +1520,6 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj .key1.*.*.*.*"){
       val expression: String = "Store.*.*.*.*"
 
-     // val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1543,8 +1562,6 @@ class jpPlusPlusTests extends FunSuite{
 
     test("Inj .*"){
       val expression: String = ".*"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1560,7 +1577,6 @@ class jpPlusPlusTests extends FunSuite{
         }
       })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
@@ -1586,20 +1602,46 @@ class jpPlusPlusTests extends FunSuite{
     test("Inj ..*"){
       val expression: String = "..*"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
       val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
       boson.go(injFuture.join())
 
       assertEquals("Vector(Map(Book -> List(Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))), Map(Title -> Scala, Pri -> 21.5, SpecialEditions -> List(Map(Title -> ScalaMachine, Price -> 40))), Map(Title -> C++, Price -> 12.6, SpecialEditions -> List(Map(Title -> C++Machine, Price -> 38)))), Hatk -> List(Map(Color -> Red, Price -> 48), Map(Color -> White, Price -> 35), Map(Color -> Blue, Price -> 38), Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))))))", future.join().getValue.toString)
-    }
+    } // No change is perform because the values are not the same type
 
     test("Inj ..* V2"){
     val expression: String = "..*"
 
-    val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("ADDED"))
+    //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("ADDED"))
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val l: List[Any] = b.decodeBsonArray(b.getByteBuf)
+      val newL: List[Any] = l.:+("ADDED")
+      val res: ByteBuf = b.encode(newL)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
     val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
 
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1607,7 +1649,7 @@ class jpPlusPlusTests extends FunSuite{
     boson.go(injFuture.join())
 
     assertEquals("Vector(Map(Book -> List(Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))), Map(Title -> Scala, Pri -> 21.5, SpecialEditions -> List(Map(Title -> ScalaMachine, Price -> 40))), Map(Title -> C++, Price -> 12.6, SpecialEditions -> List(Map(Title -> C++Machine, Price -> 38)))), Hatk -> List(Map(Color -> Red, Price -> 48), Map(Color -> White, Price -> 35), Map(Color -> Blue, Price -> 38), Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))))))", future.join().getValue.toString)
-  }
+  } // No change is perform because the values are not the same type
 
     test("Ex ..key, but multiple keys with same name"){
       val obj2: BsonObject = new BsonObject().put("Store", 1000L)
@@ -1627,7 +1669,20 @@ class jpPlusPlusTests extends FunSuite{
       val obj1: BsonObject = new BsonObject().put("Store", obj2)
       val expression: String = "..Store"
 
-      val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
+      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+        val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+        val newM: Map[String, Any] = m.+(("Street", 1000))
+        val res: ByteBuf = b.encode(newM)
+        if(res.hasArray)
+          res.array()
+        else {
+          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+          val array: Array[Byte] = buf.array()
+          buf.release()
+          array
+        }
+      })
       val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj1.encodeToBarray())
 
       val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -1636,14 +1691,13 @@ class jpPlusPlusTests extends FunSuite{
       var i: Int = 0
 
       assertEquals("Vector(Map(Store -> 1000), 1000)", future.join().getValue.toString)
-    }
+    } // No change is perform because the values are not the same type
 
     test("Inj ..key, but multiple keys with same name V2"){
       val obj22: BsonObject = new BsonObject().put("Store", new BsonObject())
       val obj11: BsonObject = new BsonObject().put("Store", obj22)
       val expression: String = "..Store"
 
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
@@ -1677,7 +1731,6 @@ class jpPlusPlusTests extends FunSuite{
       val obj111: BsonObject = new BsonObject().put("Store", arr222)
       val expression: String = "..Store[@Store]"
 
-      //val bosonI: Boson = Boson.injector(expression, (x: Map[String, Any]) => x.+(("Street", 1000)))
       val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
         val b: BosonImpl = new BosonImpl(byteArray = Option(x))
         val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)

--- a/src/test/scala/io/joson/APItests.scala
+++ b/src/test/scala/io/joson/APItests.scala
@@ -1,51 +1,29 @@
 package io.joson
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException, OutputStream}
+import java.io.ByteArrayOutputStream
 import java.util.concurrent.CompletableFuture
-
 import bsonLib.{BsonArray, BsonObject}
-import com.fasterxml.jackson.core.{JsonFactory, JsonGenerator}
-import com.fasterxml.jackson.databind.{JsonNode, JsonSerializer, ObjectMapper, SerializerProvider}
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.fasterxml.jackson.databind.module.SimpleModule
 import de.undercouch.bson4jackson.BsonFactory
 import io.boson.bson.Boson
-import io.boson.bson.bsonImpl.Dictionary._
+import io.boson.bson.bsonImpl.BosonImpl
 import io.boson.bson.bsonValue.BsValue
 import io.boson.json.Joson
 import io.boson.json.Joson.{JsonArraySerializer, JsonObjectSerializer}
 import io.netty.buffer.{ByteBuf, Unpooled}
-import io.netty.util.{ByteProcessor, ResourceLeakDetector}
-import io.vertx.core.json.{Json, JsonArray, JsonObject}
+import io.netty.util.ResourceLeakDetector
+import io.vertx.core.json.{JsonArray, JsonObject}
 import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
-
-import scala.collection.immutable.List
-import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
-import scala.collection.JavaConverters._
 /**
   * Created by Ricardo Martins on 22/01/2018.
   */
-
-
 @RunWith(classOf[JUnitRunner])
 class APItests extends FunSuite{
   ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.ADVANCED)
- /* case class JsonObjectSerializer() extends JsonSerializer[JsonObject] {
-    @throws[IOException]
-    override def serialize(value: JsonObject, jgen: JsonGenerator, provider: SerializerProvider): Unit = {
-      jgen.writeObject(value.getMap)
-    }
-  }
-
-  case class JsonArraySerializer() extends JsonSerializer[JsonArray] {
-    @throws[IOException]
-    override def serialize(value: JsonArray, jgen: JsonGenerator, provider: SerializerProvider): Unit = {
-      jgen.writeObject(value.getList)
-    }
-  }*/
 
   val hat3: BsonObject = new BsonObject().put("Price", 38).put("Color", "Blue")
   val hat2: BsonObject = new BsonObject().put("Price", 35).put("Color", "White")
@@ -64,15 +42,11 @@ class APItests extends FunSuite{
   val store: BsonObject = new BsonObject().put("Book", books).put("Hat", hats)
   val bson: BsonObject = new BsonObject().put("Store", store)
 
-
   val json = "{\"Store\":{\"Book\":[{\"Title\":\"Java\",\"SpecialEditions\":[{\"Title\":\"JavaMachine\",\"Price\":39}],\"Price\":15.5},{\"Title\":\"Scala\",\"Price\":21.5,\"SpecialEditions\":[{\"Title\":\"ScalaMachine\",\"Price\":40}]},{\"Title\":\"C++\",\"Price\":12.6,\"SpecialEditions\":[{\"Title\":\"C++Machine\",\"Price\":38}]}],\"Hat\":[{\"Price\":48,\"Color\":\"Red\"},{\"Price\":35,\"Color\":\"White\"},{\"Price\":38,\"Color\":\"Blue\"}]}}"
-
-
 
   test("json"){
     //String => Json Object
     val a: JsonObject = new JsonObject(json)
-
     //Set the Mapper with JsonObject and JsonArray Serializer
     val mapper: ObjectMapper = new ObjectMapper(new BsonFactory())
     val os = new ByteArrayOutputStream
@@ -80,13 +54,8 @@ class APItests extends FunSuite{
     module.addSerializer(classOf[JsonObject],new JsonObjectSerializer)
     module.addSerializer(classOf[JsonArray], new JsonArraySerializer)
     mapper.registerModule(module)
-
     //convert JsonObject
     mapper.writeValue(os, a)
-
-    //print encoded json
-    //os.toByteArray.foreach(b => println(b.toChar + "  " + b.toInt))
-
     //convert from byte[] to JsonNode
     val s: JsonNode = mapper.readTree(os.toByteArray)
     os.flush()
@@ -95,17 +64,25 @@ class APItests extends FunSuite{
     println(json)
   }
 
-
   test("json == bson") {
-
-    /*
-    * Injection
-    * */
     val expression = "Store"
-
     println("WORK WITH JOSON\n")
     println("|-------- Perform Injection --------|\n")
-    val joson: Joson = Joson.injector(expression, (in: Map[String, Any]) => in.+(("WHAT", 10)))
+    val joson: Joson = Joson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("newField!", 100))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+
     val midResult: CompletableFuture[String] = joson.go(json)
     val result: String = midResult.join()
     println("|-------- Perform Extraction --------|\n")
@@ -115,11 +92,23 @@ class APItests extends FunSuite{
     val json1: Any = future.join().getValue
     println(json1)
 
-
     println("WORK WITH BOSON\n")
     println("|-------- Perform Injection --------|\n")
     val validBsonArray: Array[Byte] = bson.encodeToBarray
-    val boson: Boson = Boson.injector(expression,(in: Map[String, Any]) => in.+(("WHAT", 10)))
+    val boson: Boson = Boson.injector(expression,(x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = b.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("newField!", 100))
+      val res: ByteBuf = b.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
     val midResult1: CompletableFuture[Array[Byte]] = boson.go(validBsonArray)
     val result1: Array[Byte] = midResult1.join()
     println("|-------- Perform Extraction --------|\n")
@@ -129,12 +118,9 @@ class APItests extends FunSuite{
     val bson1: Any = future1.join().getValue
     println(bson1)
 
-
     println("|-------- Perform Assertion --------|\n\n")
     assertEquals(json1, bson1)
 
-   // assertEquals(Vector(Map("Book" -> List(Map("Price" -> 15.5, "SpecialEditions" -> List(Map("Price" -> 39, "Title" -> "JavaMachine")), "Title" -> "Java"), Map("Price" -> 21.5, "SpecialEditions" -> List(Map("Price" -> 40, "Title" -> "ScalaMachine")), "Title" -> "Scala"), Map("Price" -> 12.6, "SpecialEditions" -> List(Map("Price" -> 38, "Title" -> "C++Machine")), "Title" -> "C++")), "Hat" -> List(Map("Color" -> "Red", "Price" -> 48), Map("Color" -> "White", "Price" -> 35), Map("Color" -> "Blue", "Price" -> 38)), "WHAT!!!" -> 10)),future.join().getValue  )
   }
-
 }
 


### PR DESCRIPTION
Maps and Lists removed from Implementation.
Injection deals with BsonObjects and BsonArrays as byte arrays.
Keys can have more than one wildcard (*)
bug with matching keys with wildcard fixed