### PR TITLE
Array select expressions

### DIFF
--- a/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
@@ -719,7 +719,7 @@ class BosonImpl(
                 case None =>
                   limitList.head._1 match {
                     case Some(_) if limitList.head._3.equals(C_END) =>
-                      //println("case END")
+                      println("case END")
                       arrayFRIdx - finishReaderIndex match {
                         case 1 =>
                           //println("THIS IS LAST POSITION")
@@ -729,7 +729,7 @@ class BosonImpl(
                               val midResult: Iterable[Any] = extractFromBsonArray(netty,valueLength2, finishReaderIndex, keyList, limitList.drop(1))
                               if(midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                             case _ =>
-                              //println("keylist.size > 1, calling gothrough")
+                              println("keylist.size > 1, calling gothrough")
                               val midResult: Iterable[Any] = goThroughArrayWithLimit(netty, valueLength2, finishReaderIndex, keyList.drop(1), limitList.drop(1))
                               if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                           }
@@ -756,6 +756,7 @@ class BosonImpl(
                   }
               }
             } else {
+              println("gothrough, bsonarray, NOT  EMPTY_KEY")
               limitList.head._2 match {
                 case Some(_) if iter >= limitList.head._1.get && iter <= limitList.head._2.get =>
                   keyList.head._1 match {
@@ -780,8 +781,10 @@ class BosonImpl(
                 case None =>
                   limitList.head._1 match {
                     case Some(_) if limitList.head._3.equals(C_END) =>
+                      //println("case END")
                       arrayFRIdx - finishReaderIndex match {
                         case 1 =>
+                          //println("THIS IS LAST POSITION")
                           keyList.head._1 match {
                             case STAR if keyList.size < 2 =>
                               Some(traverseBsonArray(netty, valueLength2, finishReaderIndex, keyList, limitList.drop(1))) match {
@@ -799,6 +802,7 @@ class BosonImpl(
                               if(midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                           }
                         case _ =>
+                          //println("NOT LAST POSITION")
                           netty.readerIndex(finishReaderIndex)
                           None
                       }
@@ -947,8 +951,7 @@ class BosonImpl(
                 Some(C_MATCH)
               case C_LIMIT =>
                 Some(extractFromBsonObj(netty.readerIndex(start+4),keyList,finish,limitList)) match {
-                  case Some(value) if value.isEmpty =>
-                    Some(C_MATCH)
+                  case Some(value) if value.isEmpty => Some(C_MATCH)
                   case Some(value) =>
                     val arr: Array[Byte] = new Array[Byte](finish - start)
                     netty.getBytes(start, arr, 0, finish - start)
@@ -991,25 +994,19 @@ class BosonImpl(
                 }
             }
           } else {
-            //println("findElements, didnt matched with BsonArray")
             val arrayStartReaderIndex: Int = netty.readerIndex()
             val valueLength: Int = netty.readIntLE()
             val arrayFinishReaderIndex: Int = arrayStartReaderIndex + valueLength
-            //println(s"this array end at $arrayFinishReaderIndex readerIndex")
             keyList.head._2 match {
               case C_LIMITLEVEL =>
-              netty.readerIndex(arrayFinishReaderIndex)
-              None
+                netty.readerIndex(arrayFinishReaderIndex)
+                None
               case C_LIMIT =>
-                //println("case Limit")
-                //println(s"readerIndex at this point -> ${netty.readerIndex()}")
-                Some(extractFromBsonObj(netty.readerIndex(start+4),keyList,finish,limitList)) match {
+                Some(extractFromBsonObj(netty.readerIndex(start + 4), keyList, finish, limitList)) match {
                   case Some(value) if value.isEmpty =>
-                    //println("didnt found!!!")
                     netty.readerIndex(arrayFinishReaderIndex)
                     None
                   case Some(value) =>
-                    //println("found!!!")
                     netty.readerIndex(arrayFinishReaderIndex)
                     //println(s"readerIndex at this point -> ${netty.readerIndex()}")
                     Some(resultComposer(value.toVector))

--- a/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
@@ -70,7 +70,7 @@ class BosonImpl(
     compareKeys(netty, key)
   }
 
-  private val arrKeyDecode: ListBuffer[Byte] = new ListBuffer[Byte]()
+  //private val arrKeyDecode: ListBuffer[Byte] = new ListBuffer[Byte]()
 
   def extract(netty1: ByteBuf, keyList: List[(String, String)],
               limitList: List[(Option[Int], Option[Int], String)]): Option[Any] = {
@@ -403,14 +403,14 @@ class BosonImpl(
     }
   }
 
-  private def extractKeys(netty: ByteBuf): Unit = {
-    var i: Int = netty.readerIndex()
-    while (netty.getByte(i) != 0) {
-      arrKeyDecode.append(netty.readByte())
-      i += 1
-    }
-    netty.readByte() // consume the end String byte
-  }
+//  private def extractKeys(netty: ByteBuf): Unit = {
+//    var i: Int = netty.readerIndex()
+//    while (netty.getByte(i) != 0) {
+//      arrKeyDecode.append(netty.readByte())
+//      i += 1
+//    }
+//    netty.readByte() // consume the end String byte
+//  }
 
   private def compareKeys(netty: ByteBuf, key: String): Boolean = {
     val arrKeyExtract: ListBuffer[Byte] = new ListBuffer[Byte]
@@ -434,61 +434,61 @@ class BosonImpl(
   }
 
   // Constructs a new BsonObject
-  private def traverseBsonObj(netty: ByteBuf, mapper: Map[Any, Any], bsonFinishReaderIndex: Int, keyList: List[(String, String)],limitList: List[(Option[Int], Option[Int], String)]): Map[Any, Any] = {
-    arrKeyDecode.clear()
-    val seqType: Int = netty.readByte().toInt
-    val newMap: Map[Any, Any] =
-      seqType match {
-        case D_FLOAT_DOUBLE =>
-          extractKeys(netty)
-          val value: Double = netty.readDoubleLE()
-          mapper + (new String(arrKeyDecode.toArray) -> value)
-        case D_ARRAYB_INST_STR_ENUM_CHRSEQ =>
-          extractKeys(netty)
-          val valueLength: Int = netty.readIntLE()
-          val value: CharSequence = netty.readCharSequence(valueLength, charset)
-          val newValue: String = value.toString.filter(p => p.!=(0))
-          mapper + (new String(arrKeyDecode.toArray) -> newValue)
-        case D_BSONOBJECT =>
-          extractKeys(netty)
-          val bsonStartReaderIndex: Int = netty.readerIndex()
-          val valueTotalLength: Int = netty.readIntLE()
-          val bsonFinishReaderIndex: Int = bsonStartReaderIndex + valueTotalLength
-          val map: Map[Any, Any] = scala.collection.immutable.Map[Any, Any]()
-          mapper + (new String(arrKeyDecode.toArray) -> traverseBsonObj(netty, map, bsonFinishReaderIndex, keyList,limitList))
-        case D_BSONARRAY =>
-          extractKeys(netty)
-          val arrayStartReaderIndex: Int = netty.readerIndex()
-          val valueLength: Int = netty.readIntLE()
-          val arrayFinishReaderIndex: Int = arrayStartReaderIndex + valueLength
-          mapper + (new String(arrKeyDecode.toArray) -> Compose.composer(traverseBsonArray(netty, valueLength, arrayFinishReaderIndex, keyList, limitList).toArray))
-        case D_BOOLEAN =>
-          extractKeys(netty)
-          val value: Int = netty.readByte()
-          mapper + (new String(arrKeyDecode.toArray) -> (value == 1))
-        case D_NULL =>
-          extractKeys(netty)
-          mapper + (new String(arrKeyDecode.toArray) -> null)
-        case D_INT =>
-          extractKeys(netty)
-          val value: Int = netty.readIntLE()
-          mapper + (new String(arrKeyDecode.toArray) -> value)
-        case D_LONG =>
-          extractKeys(netty)
-          val value: Long = netty.readLongLE()
-          mapper + (new String(arrKeyDecode.toArray) -> value)
-        case D_ZERO_BYTE =>
-          mapper
-      }
-    arrKeyDecode.clear()
-    val actualPos: Int = bsonFinishReaderIndex - netty.readerIndex()
-    actualPos match {
-      case x if x > 0 =>
-        traverseBsonObj(netty, newMap, bsonFinishReaderIndex, keyList, limitList)
-      case 0 =>
-        newMap
-    }
-  }
+//  private def traverseBsonObj(netty: ByteBuf, mapper: Map[Any, Any], bsonFinishReaderIndex: Int, keyList: List[(String, String)],limitList: List[(Option[Int], Option[Int], String)]): Map[Any, Any] = {
+//    arrKeyDecode.clear()
+//    val seqType: Int = netty.readByte().toInt
+//    val newMap: Map[Any, Any] =
+//      seqType match {
+//        case D_FLOAT_DOUBLE =>
+//          extractKeys(netty)
+//          val value: Double = netty.readDoubleLE()
+//          mapper + (new String(arrKeyDecode.toArray) -> value)
+//        case D_ARRAYB_INST_STR_ENUM_CHRSEQ =>
+//          extractKeys(netty)
+//          val valueLength: Int = netty.readIntLE()
+//          val value: CharSequence = netty.readCharSequence(valueLength, charset)
+//          val newValue: String = value.toString.filter(p => p.!=(0))
+//          mapper + (new String(arrKeyDecode.toArray) -> newValue)
+//        case D_BSONOBJECT =>
+//          extractKeys(netty)
+//          val bsonStartReaderIndex: Int = netty.readerIndex()
+//          val valueTotalLength: Int = netty.readIntLE()
+//          val bsonFinishReaderIndex: Int = bsonStartReaderIndex + valueTotalLength
+//          val map: Map[Any, Any] = scala.collection.immutable.Map[Any, Any]()
+//          mapper + (new String(arrKeyDecode.toArray) -> traverseBsonObj(netty, map, bsonFinishReaderIndex, keyList,limitList))
+//        case D_BSONARRAY =>
+//          extractKeys(netty)
+//          val arrayStartReaderIndex: Int = netty.readerIndex()
+//          val valueLength: Int = netty.readIntLE()
+//          val arrayFinishReaderIndex: Int = arrayStartReaderIndex + valueLength
+//          mapper + (new String(arrKeyDecode.toArray) -> Compose.composer(traverseBsonArray(netty, valueLength, arrayFinishReaderIndex, keyList, limitList).toArray))
+//        case D_BOOLEAN =>
+//          extractKeys(netty)
+//          val value: Int = netty.readByte()
+//          mapper + (new String(arrKeyDecode.toArray) -> (value == 1))
+//        case D_NULL =>
+//          extractKeys(netty)
+//          mapper + (new String(arrKeyDecode.toArray) -> null)
+//        case D_INT =>
+//          extractKeys(netty)
+//          val value: Int = netty.readIntLE()
+//          mapper + (new String(arrKeyDecode.toArray) -> value)
+//        case D_LONG =>
+//          extractKeys(netty)
+//          val value: Long = netty.readLongLE()
+//          mapper + (new String(arrKeyDecode.toArray) -> value)
+//        case D_ZERO_BYTE =>
+//          mapper
+//      }
+//    arrKeyDecode.clear()
+//    val actualPos: Int = bsonFinishReaderIndex - netty.readerIndex()
+//    actualPos match {
+//      case x if x > 0 =>
+//        traverseBsonObj(netty, newMap, bsonFinishReaderIndex, keyList, limitList)
+//      case 0 =>
+//        newMap
+//    }
+//  }
 
   // Constructs a new BsonArray with limits
   private def traverseBsonArray(netty: ByteBuf, length: Int, arrayFRIdx: Int, keyList: List[(String, String)], limitList: List[(Option[Int], Option[Int], String)]): Iterable[Any] = {
@@ -682,7 +682,7 @@ class BosonImpl(
 
     def goThrough(iter: Int, flag: Option[Boolean] = None): Iterable[Any] = {
       val seqType2: Int = netty.readByte().toInt
-      println(s"seqType2 -> $seqType2, at readerIndex -> ${netty.readerIndex()}")
+      //println(s"seqType2 -> $seqType2, at readerIndex -> ${netty.readerIndex()}")
       if (seqType2 != 0) {
         readArrayPos(netty)
       }
@@ -716,11 +716,11 @@ class BosonImpl(
             }
           case D_BSONOBJECT =>
             val bsonStartReaderIndex: Int = netty.readerIndex()
-            println(s"bsonStartReaderIndex -> $bsonStartReaderIndex")
+            //println(s"bsonStartReaderIndex -> $bsonStartReaderIndex")
             val valueTotalLength: Int = netty.readIntLE()
-            println(s"valueTotalLength -> $valueTotalLength")
+            //println(s"valueTotalLength -> $valueTotalLength")
             val bsonFinishReaderIndex: Int = bsonStartReaderIndex + valueTotalLength
-            println(s"bsonFinishReaderIndex -> $bsonFinishReaderIndex")
+            //println(s"bsonFinishReaderIndex -> $bsonFinishReaderIndex")
             //println(s"going through arr, found obj, keylist: $keyList, limitlist: $limitList")
             limitList.head._2 match {
               case Some(_) if iter >= limitList.head._1.get && iter <= limitList.head._2.get =>
@@ -739,10 +739,10 @@ class BosonImpl(
               case None =>
                 limitList.head._1 match {
                   case Some(_) if limitList.head._3.equals(C_END) =>
-                    println("going through array, found BsonObject, inside case END")
+                    //println("going through array, found BsonObject, inside case END")
                     arrayFRIdx - bsonFinishReaderIndex match {
                       case 1 =>
-                        println("This is last position!!!")
+                        //println("This is last position!!!")
                         keyList.head._2 match {
                           case C_LIMIT if keyList.head._1.equals(EMPTY_KEY) => //case ..[#]
                             //println("going through array, found obj, calling extractFromBsonObj")
@@ -754,11 +754,11 @@ class BosonImpl(
                             if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                         }
                       case x =>
-                        println(s"This is NOT the last position!!!, value of next byte: $x, at readerIndex: ${bsonFinishReaderIndex+1}")
+                        //println(s"This is NOT the last position!!!, value of next byte: $x, at readerIndex: ${bsonFinishReaderIndex+1}")
 //                        println(netty.getByte(bsonFinishReaderIndex+2).toChar)
 //                        println(netty.getByte(bsonFinishReaderIndex+3).toChar)
                         netty.readerIndex(bsonFinishReaderIndex)
-                        println(s"global array ends at readerIndex: $arrayFRIdx")
+                        //println(s"global array ends at readerIndex: $arrayFRIdx")
                         None
                     }
                   case Some(_) if iter >= limitList.head._1.get =>
@@ -1013,7 +1013,7 @@ class BosonImpl(
                 }
             }
           case D_ZERO_BYTE =>
-            println("ZERO BYTE")
+            //println("ZERO BYTE")
             None
         }
       val actualPos2: Int = arrayFRIdx - netty.readerIndex()
@@ -1072,8 +1072,20 @@ class BosonImpl(
             val bsonStartReaderIndex: Int = netty.readerIndex()
             val valueTotalLength: Int = netty.readIntLE()
             val bsonFinishReaderIndex: Int = bsonStartReaderIndex + valueTotalLength
-            netty.readerIndex(bsonFinishReaderIndex)
-            Some(C_MATCH)
+            keyList.head._2 match {
+              case C_LIMITLEVEL =>
+                netty.readerIndex(bsonFinishReaderIndex)
+                Some(C_MATCH)
+              case C_LIMIT =>
+                Some(extractFromBsonObj(netty.readerIndex(start+4),keyList,finish,limitList)) match {
+                  case Some(value) if value.isEmpty =>
+                    Some(C_MATCH)
+                  case Some(value) =>
+                    val arr: Array[Byte] = new Array[Byte](finish - start)
+                    netty.getBytes(start, arr, 0, finish - start)
+                    Some(resultComposer(Vector(Vector(arr),resultComposer(value.toVector))))
+                }
+            }
           } else {
             val bsonStartReaderIndex: Int = netty.readerIndex()
             val valueTotalLength: Int = netty.readIntLE()
@@ -1109,14 +1121,18 @@ class BosonImpl(
             val arrayStartReaderIndex: Int = netty.readerIndex()
             val valueLength: Int = netty.readIntLE()
             val arrayFinishReaderIndex: Int = arrayStartReaderIndex + valueLength
+            println("findElements, matched with BsonArray")
             keyList.head._2 match {
               case C_LIMITLEVEL =>
               netty.readerIndex(arrayFinishReaderIndex)
               None
               case C_LIMIT =>
+                println("case Limit")
                 Some(extractFromBsonArray(netty,valueLength,arrayFinishReaderIndex,keyList,limitList)) match {
                   case Some(value) if value.isEmpty => None
-                  case Some(value) => Some(resultComposer(value.toVector))
+                  case Some(value) =>
+                    println("returned with something")
+                    Some(resultComposer(value.toVector))
                 }
             }
           }
@@ -1691,7 +1707,7 @@ class BosonImpl(
     }
     list.+=(netty.readByte()) //  consume the end Pos byte
     val stringList: ListBuffer[Char] = list.map(b => b.toInt.toChar)
-    println(s"readArrayPos: ${stringList.head}")
+    //println(s"readArrayPos: ${stringList.head}")
     stringList.head
   }
 

--- a/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
@@ -183,7 +183,7 @@ class BosonImpl(
                 netty.readerIndex(bFnshRdrIndex)
                 None
               case _ =>
-                println("traversing BsonObject, didnt match with bsonobj, calling extractFromBsonObj")
+                //println("traversing BsonObject, didnt match with bsonobj, calling extractFromBsonObj")
                 val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bFnshRdrIndex, limitList)
                 if (midResult.isEmpty) None else{val res: Vector[Any] = resultComposer(midResult.toVector); Some(res)} //Some(resultComposer(midResult.toVector))
             }
@@ -217,14 +217,18 @@ class BosonImpl(
                 netty.readerIndex(arrayFinishReaderIndex)
                 Some(arr)
               case (C_LIMIT | C_LIMITLEVEL) if keyList.size > 1 && keyList.drop(1).head._2.equals(C_FILTER)=>
-                println("extractingFromBsonObject, matched with Array case filter, callling goThrough")
+                //println("extractingFromBsonObject, matched with Array case filter, callling goThrough")
                 //println("extractFromBsonObj -> matched with BsonArray -> case Filter")
                 Some(goThroughArrayWithLimit(netty,valueLength,arrayFinishReaderIndex,keyList,limitList)) match {
                   case Some(value) if value.isEmpty => None
                   case Some(value) =>
-                    println("OUT OF extractingFromBsonObject, matched with Array case filter, callling goThrough")
+                    //println("OUT OF extractingFromBsonObject, matched with Array case filter, callling goThrough")
                     Some(resultComposer(value.toVector))
                 }
+//              case C_LIMIT =>
+//                println("extractFromBsonObj, matched with BsonArray, calling extractFromBsonArray with no drops")
+//                val midResult: Iterable[Any] = extractFromBsonArray(netty, valueLength, arrayFinishReaderIndex, keyList, limitList)
+//                if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
               case _ if keyList.size > 1 =>
                 //println("extractFromBsonObj; BsonArray case; calling goThrough")
                 Some(goThroughArrayWithLimit(netty,valueLength,arrayFinishReaderIndex,keyList.drop(1),limitList)) match {
@@ -252,7 +256,7 @@ class BosonImpl(
                 None
               case _ =>
                 println("traversing BsonObject, didnt match, calling extractFromBsonArray")
-                println(s"keylist: $keyList, limitlist: $limitList")
+                //println(s"keylist: $keyList, limitlist: $limitList")
                 val midResult: Iterable[Any] = extractFromBsonArray(netty, valueLength, arrayFinishReaderIndex, keyList, limitList)
                 if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
             }
@@ -330,19 +334,32 @@ class BosonImpl(
         }
       case EMPTY_KEY if keyList.head._2.equals(C_LIMIT) =>
         //TODO:Working but not sure if 100%, if not implement the all array range at beginning but in positions that ain't inside the original range add this head to limitlist
-        println("extractFromBsonArray, case EMPTY_KEY, condition LIMIT")
-        println("calling goThroughArrayWithLimit with duplicate, constructing")
+        //println("extractFromBsonArray, case EMPTY_KEY, condition LIMIT")
+        //println("calling goThroughArrayWithLimit with duplicate, constructing")
         val constructed: Iterable[Any] = goThroughArrayWithLimit(netty.duplicate(), length, arrayFRIdx, keyList.drop(1), limitList)
-        println(s"out of goThroughArrayWithLimit with duplicate, constructed: $constructed")
-        println("calling goThroughArrayWithLimit again but this time with List((Some(0), None, TO_RANGE)) on limitlist and no keylist drop")
+        //println(s"out of goThroughArrayWithLimit with duplicate, constructed: $constructed")
+        //println("calling goThroughArrayWithLimit again but this time with List((Some(0), None, TO_RANGE)) on limitlist and no keylist drop")
         Some(goThroughArrayWithLimit(netty, length, arrayFRIdx, keyList, List((Some(0), None, TO_RANGE)) ++ limitList)) match {
           case Some(x) if x.isEmpty =>
-            println("out of goThroughArrayWithLimit but res is empty")
+            //println("out of goThroughArrayWithLimit but res is empty")
             Some(resultComposer(constructed.toVector))
           case Some(value) =>
-            println(s"out of goThroughArrayWithLimit with res: $value")
+            //println(s"out of goThroughArrayWithLimit with res: $value")
             Some(Vector(resultComposer(constructed.toVector), resultComposer(value.toVector)))
         }
+//      case _ if keyList.head._2.equals(C_LIMIT)=>
+//        println("non important key, condition LIMIT, calling traverseBsonArray")
+//        val constructed: Iterable[Any] = traverseBsonArray(netty.duplicate(), length, arrayFRIdx, keyList, limitList)
+//        println(s"constructed: $constructed")
+//        println("calling gothrough with List((Some(0), None, TO_RANGE)) ++ limitList")
+//        Some(goThroughArrayWithLimit(netty, length, arrayFRIdx, keyList, List((Some(0), None, TO_RANGE)) ++ limitList)) match {
+//          case Some(x) if x.isEmpty =>
+//            println("out of goThroughArrayWithLimit but res is empty")
+//            Some(resultComposer(constructed.toVector))
+//          case Some(value) =>
+//            println(s"out of goThroughArrayWithLimit with res: $value")
+//            Some(Vector(resultComposer(constructed.toVector), resultComposer(value.toVector)))
+//        }
       case EMPTY_KEY if keyList.size < 2 =>
         //println("calling traverseBsonArray")
         Some(traverseBsonArray(netty, length, arrayFRIdx, keyList, limitList)) match {
@@ -682,18 +699,11 @@ class BosonImpl(
           newSeq
       }
     }
-//    println(s"keyList: $keyList")
-//    println(s"limitList: $limitList")
     val seq: Iterable[Any] = constructWithLimits(0)
     limitList.head._3 match {
-      case UNTIL_RANGE =>
-        //println(s"before apply until -> $seq")
-        //println(s"after apply until -> ${seq.take(seq.size-1)}")
-        seq.take(seq.size-1)
+      case UNTIL_RANGE => seq.take(seq.size-1)
       case C_END => seq.drop(seq.size-1)
-      case _ =>
-        //println(s"seq: $seq")
-        seq
+      case _ => seq
     }
   }
 
@@ -727,7 +737,7 @@ class BosonImpl(
                 }
             }
           case D_ARRAYB_INST_STR_ENUM_CHRSEQ =>
-            println(s"case STRING; limitList: $limitList")
+            //println(s"case STRING; limitList: $limitList")
             val valueLength: Int = netty.readIntLE()
             netty.readCharSequence(valueLength, charset)
             limitList.head._2 match {
@@ -750,16 +760,9 @@ class BosonImpl(
             println(s"going through arr, found obj, keylist: $keyList, limitlist: $limitList")
             limitList.head._2 match {
               case Some(_) if iter >= limitList.head._1.get && iter <= limitList.head._2.get =>
-                keyList.head._2 match {
-                  case C_LIMIT if keyList.head._1.equals(EMPTY_KEY) && limitList.size == 1 => //case ..[#]
-                    val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList)
-                    if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
-                  case _ =>
-                    val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))  //check this drop
-                    if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
-                }
+                val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1)) //check this drop
+                if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
               case Some(_) =>
-                //println("not inside limits")
                 netty.readerIndex(bsonFinishReaderIndex)
                 None
               case None =>
@@ -768,7 +771,7 @@ class BosonImpl(
                     //println("going through array, found BsonObject, inside case END")
                     arrayFRIdx - bsonFinishReaderIndex match {
                       case 1 =>
-                        println("This is last position!!!")
+                        //println("This is last position!!!")
                         val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))
                         if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                       case _ =>
@@ -778,7 +781,7 @@ class BosonImpl(
                   case Some(_) if iter >= limitList.head._1.get =>
                     //println("normal case inside limits")
                     //println("going through array, found obj, case LIMIT EMPTY_KEY, calling extractFromBsonObj")
-                    val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))
+                     val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))
                     if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                   case Some(_) =>
                     netty.readerIndex(bsonFinishReaderIndex)
@@ -787,11 +790,11 @@ class BosonImpl(
                     //println(s"going through arr, found BsonObj, matching keylist condition: ${keyList.head._2}")
                     keyList.head._2 match { //TODO:missing case C_LIMIT, not implemented yet besides de filter case
                       case (C_LIMIT | C_LIMITLEVEL) if keyList.size >1 && keyList.drop(1).head._2.equals(C_FILTER) && !limitList.head._3.equals(STAR) =>
-                        println(s"going to call findElements, current keyList: $keyList,   current limitList: $limitList")
+                        //println(s"going to call findElements, current keyList: $keyList,   current limitList: $limitList")
                         val copyNetty1: ByteBuf = netty.duplicate()
                         val copyNetty2: ByteBuf = netty.duplicate()
                         val res = findElements(copyNetty1,copyNetty2, keyList, limitList, bsonStartReaderIndex, bsonFinishReaderIndex)  // keylist still with ("",...)("",filter)
-                        println(s"out of findElements with res: $res")
+                        //println(s"out of findElements with res: $res")
                         if(res.isEmpty) {
                           netty.readerIndex(bsonFinishReaderIndex)
                           None
@@ -799,20 +802,6 @@ class BosonImpl(
                           netty.readerIndex(bsonFinishReaderIndex)
                           Some(resultComposer(res.toVector))
                         }
-                      // match {
-//                          case Seq() =>
-//                            netty.readerIndex(copyNetty.readerIndex())
-//                            None
-//                          case _ if keyList.size > 1 =>
-//                            //println(s"findElements; found a match with ${keyList.head}")
-//                            val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList.drop(1), bsonFinishReaderIndex, limitList.drop(1))  // keylist drop!!
-//                            if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
-//                          case _ =>
-//                            val arr: Array[Byte] = new Array[Byte](valueTotalLength)
-//                            netty.getBytes(bsonStartReaderIndex, arr, 0, valueTotalLength)
-//                            netty.readerIndex(bsonFinishReaderIndex)
-//                            Some(arr)
-//                        }
                       case (C_LEVEL | C_ALL | C_LIMITLEVEL) =>
                         //println("goThrough; BsonObject case; condition = 'level' or 'all'")
                         val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))
@@ -1121,40 +1110,40 @@ class BosonImpl(
                 netty.readerIndex(arrayFinishReaderIndex)
                 Some(C_MATCH)
               case C_LIMIT =>
-                println("matched with array, gonna look inside")
+                //println("matched with array, gonna look inside")
                 Some(extractFromBsonObj(netty.readerIndex(start+4),keyList,finish,limitList)) match {
                   case Some(value) if value.isEmpty =>
-                    println("didnt found!!!")
+                    //println("didnt found!!!")
                     Some(C_MATCH)
                   case Some(value) =>
-                    println("found!!!")
+                    //println("found!!!")
                     val arr: Array[Byte] = new Array[Byte](finish - start)
                     netty.getBytes(start, arr, 0, finish - start)
                     Some(resultComposer(Vector(Vector(arr),resultComposer(value.toVector))))
                 }
             }
           } else {
-            println("findElements, didnt matched with BsonArray")
+            //println("findElements, didnt matched with BsonArray")
             val arrayStartReaderIndex: Int = netty.readerIndex()
             val valueLength: Int = netty.readIntLE()
             val arrayFinishReaderIndex: Int = arrayStartReaderIndex + valueLength
-            println(s"this array end at $arrayFinishReaderIndex readerIndex")
+            //println(s"this array end at $arrayFinishReaderIndex readerIndex")
             keyList.head._2 match {
               case C_LIMITLEVEL =>
               netty.readerIndex(arrayFinishReaderIndex)
               None
               case C_LIMIT =>
-                println("case Limit")
-                println(s"readerIndex at this point -> ${netty.readerIndex()}")
+                //println("case Limit")
+                //println(s"readerIndex at this point -> ${netty.readerIndex()}")
                 Some(extractFromBsonObj(netty.readerIndex(start+4),keyList,finish,limitList)) match {
                   case Some(value) if value.isEmpty =>
-                    println("didnt found!!!")
+                    //println("didnt found!!!")
                     netty.readerIndex(arrayFinishReaderIndex)
                     None
                   case Some(value) =>
-                    println("found!!!")
+                    //println("found!!!")
                     netty.readerIndex(arrayFinishReaderIndex)
-                    println(s"readerIndex at this point -> ${netty.readerIndex()}")
+                    //println(s"readerIndex at this point -> ${netty.readerIndex()}")
                     Some(resultComposer(value.toVector))
                 }
             }

--- a/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
@@ -219,7 +219,7 @@ class BosonImpl(
               case (C_LIMIT | C_LIMITLEVEL) if keyList.size > 1 && keyList.drop(1).head._2.equals(C_FILTER)=>
                 println("extractingFromBsonObject, matched with Array case filter, callling goThrough")
                 //println("extractFromBsonObj -> matched with BsonArray -> case Filter")
-                Some(goThroughArrayWithLimit(netty,valueLength,arrayFinishReaderIndex,keyList,limitList)) match { //TODO: tests this keylist without drop!!!
+                Some(goThroughArrayWithLimit(netty,valueLength,arrayFinishReaderIndex,keyList,limitList)) match {
                   case Some(value) if value.isEmpty => None
                   case Some(value) =>
                     println("OUT OF extractingFromBsonObject, matched with Array case filter, callling goThrough")
@@ -924,7 +924,7 @@ class BosonImpl(
                 case None =>
                   limitList.head._1 match {
                     case Some(_) if limitList.head._3.equals(C_END) =>
-                      arrayFRIdx - finishReaderIndex match {  //TODO:tests it
+                      arrayFRIdx - finishReaderIndex match {
                         case 1 =>
                           keyList.head._1 match {
                             case STAR if keyList.size < 2 =>

--- a/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/BosonImpl.scala
@@ -252,7 +252,7 @@ class BosonImpl(
                 None
               case _ =>
                 println("traversing BsonObject, didnt match, calling extractFromBsonArray")
-                //println(s"keylist: $keyList, limitlist: $limitList")
+                println(s"keylist: $keyList, limitlist: $limitList")
                 val midResult: Iterable[Any] = extractFromBsonArray(netty, valueLength, arrayFinishReaderIndex, keyList, limitList)
                 if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
             }
@@ -769,33 +769,17 @@ class BosonImpl(
                     arrayFRIdx - bsonFinishReaderIndex match {
                       case 1 =>
                         println("This is last position!!!")
-                        keyList.head._2 match {
-                          case C_LIMIT if keyList.head._1.equals(EMPTY_KEY) => //case ..[#]
-                            println("going through array, found obj, calling extractFromBsonObj")
-                            val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList) //TODO: check if limitlist doens't need a drop like the next case of C_LIMIT
-                            if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
-                          case _ =>
-                            val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))  //check this drop
-                            //println(s"extracted from bsonobject: $midResult")
-                            if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
-                        }
+                        val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))
+                        if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                       case _ =>
                         netty.readerIndex(bsonFinishReaderIndex)
                         None
                     }
                   case Some(_) if iter >= limitList.head._1.get =>
                     //println("normal case inside limits")
-                    keyList.head._2 match {
-                      case C_LIMIT if keyList.head._1.equals(EMPTY_KEY) => //case ..[#]
-                        println("going through array, found obj, case LIMIT EMPTY_KEY, calling extractFromBsonObj")
-                        val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1)) //  modified limit to drop 1!!!
-                        if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
-                      case _ =>
-                        println("going through array, found obj, calling extractFromBsonObj")
-                        val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))  //check this drop
-                        //println(s"extracted from bsonobject: $midResult")
-                        if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
-                    }
+                    //println("going through array, found obj, case LIMIT EMPTY_KEY, calling extractFromBsonObj")
+                    val midResult: Iterable[Any] = extractFromBsonObj(netty, keyList, bsonFinishReaderIndex, limitList.drop(1))
+                    if (midResult.isEmpty) None else Some(resultComposer(midResult.toVector))
                   case Some(_) =>
                     netty.readerIndex(bsonFinishReaderIndex)
                     None
@@ -1080,8 +1064,8 @@ class BosonImpl(
       seqType match {
         case D_FLOAT_DOUBLE =>
           if (comparingFunction(netty, keyList.drop(1).head._1)) {
-            println(s"matched on Double/Float: ${netty.readDoubleLE()}")
-            //netty.readDoubleLE()
+            //println(s"matched on Double/Float: ${netty.readDoubleLE()}")
+            netty.readDoubleLE()
             Some(C_MATCH)
           } else {
             netty.readDoubleLE()
@@ -1092,8 +1076,8 @@ class BosonImpl(
             netty.readCharSequence(valueLength, charset)
             Some(C_MATCH)
           } else {
-            println(s"DIDNT MATCH ON STRING: ${netty.readCharSequence(netty.readIntLE(),charset)}")
-            //netty.readCharSequence(netty.readIntLE(),charset)
+            //println(s"DIDNT MATCH ON STRING: ${netty.readCharSequence(netty.readIntLE(),charset)}")
+            netty.readCharSequence(netty.readIntLE(),charset)
             None}
         case D_BSONOBJECT =>
           if (comparingFunction(netty, keyList.drop(1).head._1)) {
@@ -1188,8 +1172,8 @@ class BosonImpl(
           } else None
         case D_INT =>
           if (comparingFunction(netty, keyList.drop(1).head._1)) {
-            println(s"matched on Int: ${netty.readIntLE()}")
-            //netty.readIntLE()
+            //println(s"matched on Int: ${netty.readIntLE()}")
+            netty.readIntLE()
             Some(C_MATCH)
           } else {
             netty.readIntLE()

--- a/src/main/scala/io/boson/bson/bsonImpl/Dictionary.scala
+++ b/src/main/scala/io/boson/bson/bsonImpl/Dictionary.scala
@@ -50,6 +50,8 @@ object Dictionary {
   // PARSER CONSTANTS
   val P_NUMBER: String = """\d+(\.\d*)?"""
   val P_WORD: String =  """[/^[?a-zA-Z\u00C0-\u017F]+\d_-]+"""
+  val P_TO_RANGE: String = """\b(To|to)\b"""
+  val P_UNTIL_RANGE: String = """\b(Until|until)\b"""
   val P_CLOSE_BRACKET: String = "]"
   val P_OPEN_BRACKET: String = "["
   val P_HAS_ELEM: String = "[@"

--- a/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
+++ b/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
@@ -30,8 +30,8 @@ class Interpreter[T](boson: BosonImpl, program: Program, f: Option[Function[T,T]
           //println(s"dotList: $dots")
           executeMoreKeys(first, list, dots)
         case MoreKeys(first, list, dots) =>
-          //println(s"statements: ${List(first) ++ list}")
-          //println(s"dotList: $dots")
+          println(s"statements: ${List(first) ++ list}")
+          println(s"dotList: $dots")
           executeMoreKeys(first, list, dots)
         case _ => throw new RuntimeException("Something went wrong!!!")
       }
@@ -109,19 +109,39 @@ class Interpreter[T](boson: BosonImpl, program: Program, f: Option[Function[T,T]
   }
 
   private def defineLimits(left: Int, mid: Option[String], right: Option[Any]): List[(Option[Int], Option[Int], String)] = {
-    if(mid.isDefined && right.isDefined) {
-      (left, mid.get.toLowerCase, right.get) match {
-        case (a, UNTIL_RANGE, C_END) => List((Some(a),None,UNTIL_RANGE))
-        case (a, _, C_END) => List((Some(a),None,TO_RANGE))
-        case (a, expr, b) if b.isInstanceOf[Int] =>
-          expr.toLowerCase match {
-            case TO_RANGE => List((Some(a),Some(b.asInstanceOf[Int]),TO_RANGE))
-            case UNTIL_RANGE => List((Some(a),Some(b.asInstanceOf[Int]-1),TO_RANGE))
-          }
-      }
-    } else { //[#]
-      List((Some(left),Some(left),TO_RANGE))
+    mid.isDefined match {
+      case true if right.isEmpty=>
+        mid.get match {
+          case C_FIRST => List((Some(0),Some(0),TO_RANGE))
+          case C_ALL => List((Some(0),None,TO_RANGE))
+          case C_END => List((Some(0),None,C_END))
+        }
+      case true if right.isDefined =>
+        (left, mid.get.toLowerCase, right.get) match {
+          case (a, UNTIL_RANGE, C_END) => List((Some(a),None,UNTIL_RANGE))
+          case (a, _, C_END) => List((Some(a),None,TO_RANGE))
+          case (a, expr, b) if b.isInstanceOf[Int] =>
+            expr.toLowerCase match {
+              case TO_RANGE => List((Some(a),Some(b.asInstanceOf[Int]),TO_RANGE))
+              case UNTIL_RANGE => List((Some(a),Some(b.asInstanceOf[Int]-1),TO_RANGE))
+            }
+        }
+      case false =>
+        List((Some(left),Some(left),TO_RANGE))
     }
+//    if(mid.isDefined && right.isDefined) {
+//      (left, mid.get.toLowerCase, right.get) match {
+//        case (a, UNTIL_RANGE, C_END) => List((Some(a),None,UNTIL_RANGE))
+//        case (a, _, C_END) => List((Some(a),None,TO_RANGE))
+//        case (a, expr, b) if b.isInstanceOf[Int] =>
+//          expr.toLowerCase match {
+//            case TO_RANGE => List((Some(a),Some(b.asInstanceOf[Int]),TO_RANGE))
+//            case UNTIL_RANGE => List((Some(a),Some(b.asInstanceOf[Int]-1),TO_RANGE))
+//          }
+//      }
+//    } else { //[#]
+//      List((Some(left),Some(left),TO_RANGE))
+//    }
   }
 
   private def executeMoreKeys(first: Statement, list: List[Statement], dotsList: List[String]): bsonValue.BsValue = {

--- a/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
+++ b/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
@@ -25,6 +25,10 @@ class Interpreter[T](boson: BosonImpl, program: Program, f: Option[Function[T,T]
     if (statement.nonEmpty) {
 
       statement.head match {
+        case MoreKeys(first, list, dots) if first.isInstanceOf[ROOT]=>
+          //println(s"statements: ${List(first) ++ list}")
+          //println(s"dotList: $dots")
+          executeMoreKeys(first, list, dots)
         case MoreKeys(first, list, dots) =>
           //println(s"statements: ${List(first) ++ list}")
           //println(s"dotList: $dots")
@@ -47,6 +51,7 @@ class Interpreter[T](boson: BosonImpl, program: Program, f: Option[Function[T,T]
           }
         case HasElem(key, elem) => (List((key, C_LIMITLEVEL), (elem, C_FILTER)), List((None, None, EMPTY_KEY), (None, None, EMPTY_KEY)))
         case Key(key) => if (statementList.nonEmpty) (List((key, C_NEXT)), List((None, None, EMPTY_KEY))) else (List((key, C_LEVEL)), List((None, None, EMPTY_KEY)))
+        case ROOT() => (List((C_DOT,C_DOT)), List((None,None,EMPTY_RANGE)))
         case _ => throw CustomException("Error building key list")
       }
     if (statementList.nonEmpty) {
@@ -97,6 +102,7 @@ class Interpreter[T](boson: BosonImpl, program: Program, f: Option[Function[T,T]
           case C_FILTER => elem
           case C_NEXT => println("----- NOT POSSIBLE----");if(dotsList.head.equals(C_DOUBLEDOT)) (elem._1,C_ALL) else elem
           case C_ALL => elem
+          case C_DOT => elem
         }
       },limitList1)
     }

--- a/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
+++ b/src/main/scala/io/boson/bson/bsonPath/Interpreter.scala
@@ -60,7 +60,7 @@ class Interpreter[T](boson: BosonImpl, program: Program, f: Option[Function[T,T]
           statement match {
             case KeyWithArrExpr(key, arrEx) => (List((key, C_LIMITLEVEL)), defineLimits(arrEx.leftArg, arrEx.midArg, arrEx.rightArg))
             case ArrExpr(l, m, r) => (List((EMPTY_KEY, C_LIMITLEVEL)), defineLimits(l, m, r))
-            case HalfName(halfName) =>if(halfName.equals(STAR)) (List((halfName, C_ALL)), List((None, None, STAR))) else (List((halfName, C_NEXT)), List((None, None, EMPTY_KEY)))                                                                          //TODO: treat '*'
+            case HalfName(halfName) =>if(halfName.equals(STAR)) (List((halfName, C_ALL)), List((None, None, STAR))) else (List((halfName, C_NEXT)), List((None, None, EMPTY_KEY))) //TODO: treat '*'
             case HasElem(key, elem) => (List((key, C_LIMITLEVEL), (elem, C_FILTER)), List((None, None, EMPTY_KEY), (None, None, EMPTY_KEY)))
             case Key(key) => (List((key, C_NEXT)), List((None, None, EMPTY_KEY)))
             case _ => throw CustomException("Error building key list")

--- a/src/test/java/io/boson/APItests.java
+++ b/src/test/java/io/boson/APItests.java
@@ -568,7 +568,6 @@ public class APItests {
 
     @Test
     public void ExtractPosFromEveryArrayInsideOtherArrayPosEnd() {
-        System.out.println(arrEvent);
         String expression = ".[0 to 2]..[0 to end]";
         CompletableFuture<BsValue> future1 = new CompletableFuture<>();
         Boson boson = Boson.extractor(expression, future1::complete);
@@ -599,6 +598,7 @@ public class APItests {
 
     @Test
     public void ExtractPosFromEveryArrayInsideOtherArrayPosLimit() {
+        System.out.println(arrEvent);
         String expression = ".[0 to 2]..[0 to 1]";
         CompletableFuture<BsValue> future1 = new CompletableFuture<>();
         Boson boson = Boson.extractor(expression, future1::complete);
@@ -611,9 +611,10 @@ public class APItests {
         expected.add(title2.encodeToBarray());
         expected.add(edition1.encodeToBarray());
         expected.add(edition2.encodeToBarray());
+        expected.add(edition3.encodeToBarray());
         expected.add(hat1.encodeToBarray());
         expected.add(hat2.encodeToBarray());
-
+        System.out.println("result: "+result);
         assert(result.size() == expected.size());
         for(int i =0;i<result.size();i++) {
             if(result.get(i) instanceof Double) assertTrue(result.get(i) == expected.get(i));
@@ -622,7 +623,7 @@ public class APItests {
             else if(result.get(i)==null && expected.get(i)==null) assertTrue(true);
             else assertTrue(result.get(i).equals(expected.get(i)));
         }
-    }   //TODO: ..[#] ain't searching outside limits deeper, it should return the Map(Title -> C++Machine, ...)
+    }
 
     private ByteBuffer validatedByteBuffer = ByteBuffer.allocate(bson.encodeToBarray().length);
     private ByteBuffer b = validatedByteBuffer.put(bson.encodeToBarray());

--- a/src/test/java/io/boson/APItests.java
+++ b/src/test/java/io/boson/APItests.java
@@ -143,7 +143,6 @@ public class APItests {
         Boson boson = Boson.extractor(expression, future1::complete);
         boson.go(bson.encodeToBarray());
         Object result = future1.join().getValue();
-        System.out.println(result);
 
         assertEquals(
                 "Vector(21.5)",

--- a/src/test/java/io/boson/APItests.java
+++ b/src/test/java/io/boson/APItests.java
@@ -1200,6 +1200,93 @@ public class APItests {
         }
     }
 
+    @Test
+    public void ExtractArrayRoot(){
+        String expression = ".";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(arr1.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(arr1.encodeToBarray());
+
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void ExtractObjRoot(){
+        String expression = ".";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(bson.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(bson.encodeToBarray());
+
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void Extract_Coverage_1(){
+        String expression = "[end]..[end]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(arr1.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(100000L);
+        System.out.println("result: "+result);
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void ExtractFirstPosArray(){
+        System.out.println(arr1);
+        String expression = "[first]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(arr1.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add("Hat");
+        expected.add("Null");
+        expected.add(100000L);
+
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
 
 
 

--- a/src/test/java/io/boson/APItests.java
+++ b/src/test/java/io/boson/APItests.java
@@ -3,6 +3,7 @@ import bsonLib.BsonArray;
 import bsonLib.BsonObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.boson.bson.Boson;
+import io.boson.bson.bsonImpl.BosonImpl;
 import io.boson.bson.bsonValue.BsValue;
 import io.boson.json.Joson;
 import org.junit.Test;
@@ -10,13 +11,16 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
+
+import scala.None;
+import scala.Option;
+import scala.Tuple2;
+import scala.Tuple3;
 import scala.collection.JavaConverters;
 import scala.collection.immutable.Vector;
+import scala.collection.mutable.ArrayBuffer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -90,7 +94,7 @@ public class APItests {
 //        assertEquals(json1, bson1 );
 //    }
     //TODO:when merge branches with Ricardo Fix this test!!!
-
+    
     @Test
     public void ExtractFromArrayPos() {
         String expression = ".Store.Book[1 to 2]";
@@ -1264,6 +1268,186 @@ public class APItests {
     }
 
     @Test
+    public void Extract_Coverage_2(){
+        BsonArray arr1 = new BsonArray().add(new BsonArray().addNull().add(new BsonObject().put("Store",new BsonArray().addNull()))).add(false).add(2.2).addNull().add(1000L).add("Hat").add(2)
+                .add(new BsonObject().put("Quantity",500L).put("SomeObj",new BsonObject().putNull("blah")).put("one",false).putNull("three"));
+        BsonObject bE = new BsonObject().put("Store",arr1);
+        String expression = "Store[first]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(bE.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(new BsonArray().addNull().add(new BsonObject().put("Store",new BsonArray().addNull())).encodeToBarray());
+        expected.add("Null");
+
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void Extract_Coverage_3(){
+        BsonArray arr1 = new BsonArray().add(new BsonArray().addNull().add(new BsonObject().put("Store",new BsonArray().addNull()))).add(false).add(2.2).addNull().add(1000L).add("Hat").add(2)
+                .add(new BsonObject().put("Quantity",500L).put("SomeObj",new BsonObject().putNull("blah")).put("one",false).putNull("three"));
+        BsonObject bE = new BsonObject().put("Store",arr1);
+        String expression = "Store[first].*";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(bE.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add("Null");
+        expected.add(new BsonObject().put("Store",new BsonArray().addNull()).encodeToBarray());
+
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void Extract_Coverage_4(){
+        BsonArray arr1 = new BsonArray().add("Hat").add(false).add(2.2).addNull().add(1000L).add(new BsonArray().addNull().add(new BsonArray().add(100000L))).add(2);
+        System.out.println(arr1);
+        String expression = "[end].[end].*";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(arr1.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void Extract_Coverage_5(){
+        BsonArray arr1 = new BsonArray().add(new BsonArray().add(33)).add(false).add(2.2).addNull().add(1000L).add("Hat").add(2).add(new BsonArray().addNull().add(new BsonObject().put("Store",new BsonArray().addNull())));
+        BsonObject bE = new BsonObject().put("Store",arr1);
+        String expression = "Store[end].*";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(bE.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add("Null");
+        expected.add(new BsonObject().put("Store",new BsonArray().addNull()).encodeToBarray());
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void Extract_Coverage_6(){
+        BsonArray arr1 = new BsonArray().add(new BsonArray().add(33)).add(false).add(2.2).addNull().add(1000L).add("Hat").add(2).add(new BsonArray().addNull().add(new BsonObject().put("Store",new BsonArray().addNull())));
+        BsonObject bE = new BsonObject().put("Store",arr1);
+        String expression = "Store[end].Level";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(bE.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void Extract_Coverage_7(){
+        BsonArray arr1 = new BsonArray().add(new BsonArray().add(33)).add(false).add(2.2).addNull().add(1000L).add("Hat").add(2).add(new BsonArray().addNull().add(new BsonObject().put("Store",new BsonArray().addNull())));
+        BsonObject bE = new BsonObject().put("Store",arr1);
+        String expression = "Store[end]..Store";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(bE.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(new BsonArray().addNull().encodeToBarray());
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void Extract_Coverage_8(){
+        BsonArray arr1 = new BsonArray().add(new BsonArray().add(33)).add(false).add(2.2).addNull().add(1000L).add("Hat").add(2).add(new BsonArray().addNull().add(new BsonObject().put("Store",new BsonArray().addNull())));
+        BsonObject bE = new BsonObject().put("Store",arr1);
+        String expression = "Store[end].*.*";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(bE.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(new BsonArray().addNull().encodeToBarray());
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void Extract_Coverage_9(){
+        BsonArray arr1 = new BsonArray().add(new BsonArray().add(33)).add(false).add(2.2).addNull().add(1000L).add("Hat").add(2).add(new BsonArray().addNull().add(new BsonObject().put("Store",new BsonArray().addNull())));
+        BsonObject bE = new BsonObject().put("Store",arr1);
+        String expression = "Store[@elem]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(bE.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
     public void ExtractFirstPosArray(){
         System.out.println(arr1);
         String expression = "[first]";
@@ -1278,6 +1462,29 @@ public class APItests {
         expected.add("Null");
         expected.add(100000L);
 
+        assert (result.size() == expected.size());
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i), (byte[]) expected.get(i)));
+            else if (result.get(i) == null && expected.get(i) == null) assertTrue(true);
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+    }
+
+    @Test
+    public void ExtractLastPosDeep(){
+        BsonArray arr1 = new BsonArray().add("Hat").add(false).add(2.2).addNull().add(1000L).add(new BsonArray().addNull().add(new BsonArray().add(100000L))).add(2)
+                .add(new BsonObject().put("Quantity",500L).put("SomeObj",new BsonObject().putNull("blah")).put("one",false).putNull("three"))
+                .add(new BsonObject().put("Quantity",200L).put("SomeObj",new BsonObject().putNull("blink")).put("one",true).putNull("four"));
+        String expression = "[end].[end]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(arr1.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>) future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(100000L);
         assert (result.size() == expected.size());
         for (int i = 0; i < result.size(); i++) {
             if (result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
@@ -1382,7 +1589,7 @@ public class APItests {
     }
 
     @Test
-    public void ExtractWhenKeyIsInsideKey() {
+    public void ExtractWhenKeyIsInsideKey_V1() {
         BsonObject obj2 = new BsonObject().put("Store", 1000L);
         BsonObject obj1 = new BsonObject().put("Store", obj2);
         String expression = "..Store";
@@ -1431,5 +1638,134 @@ public class APItests {
                 result.toString());
     }
 
+    @Test
+    public void ExtractWhenKeyIsInsideKey_V2() {
+        BsonObject obj3 = new BsonObject().put("Store", new BsonArray());
+        BsonArray arr2 = new BsonArray().add(obj3);
+        BsonObject obj2 = new BsonObject().put("Store", arr2);
+        BsonArray arr1 = new BsonArray().add(obj2);
+        BsonObject obj1 = new BsonObject().put("Store", arr1);
+        String expression = "..Store[@Store]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(obj1.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>)future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(obj2.encodeToBarray());
+        expected.add(obj3.encodeToBarray());
+
+        assert(result.size() == expected.size());
+        for(int i =0;i<result.size();i++) {
+            if(result.get(i) instanceof Double) assertTrue(result.get(i) == expected.get(i));
+            else if(result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i),(byte[])expected.get(i)));
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+        //assertEquals("Vector(Map(Store -> 1000), 1000)", result.toString());
+    }
+
+    @Test
+    public void ExtractWhenKeyIsInsideKey_V3() {
+        BsonArray arr  = new BsonArray().add(new BsonObject().put("some", new BsonObject()).put("This", new BsonArray().add(new BsonObject().put("some", new BsonObject()).put("thing", new BsonArray()))));
+        BsonObject obj  = new BsonObject().put("This", arr);
+        String expression = "This[@some]";
+        System.out.println(obj);
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(obj.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>)future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(new BsonObject().put("some", new BsonObject()).put("This", new BsonArray().add(new BsonObject().put("some", new BsonObject()).put("thing", new BsonArray()))).encodeToBarray());
+        expected.add(new BsonObject().put("some", new BsonObject()).put("thing", new BsonArray()).encodeToBarray());
+        assert(result.size() == expected.size());
+        for(int i =0;i<result.size();i++) {
+            if(result.get(i) instanceof Double) assertTrue(result.get(i) == expected.get(i));
+            else if(result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i),(byte[])expected.get(i)));
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+        //assertEquals("Vector(Map(Store -> 1000), 1000)", result.toString());
+    }
+
+    @Test
+    public void ExtractWhenKeyIsInsideKey_V4() {
+        BsonArray arr  = new BsonArray().add(new BsonObject().put("Inside", new BsonObject()).put("This", new BsonArray().add(new BsonObject().put("some", new BsonObject()).put("thing", new BsonArray()))));
+        BsonObject obj  = new BsonObject().put("This", arr);
+        String expression = "This[@some]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(obj.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>)future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+        expected.add(new BsonObject().put("some", new BsonObject()).put("thing", new BsonArray()).encodeToBarray());
+        assert(result.size() == expected.size());
+        for(int i =0;i<result.size();i++) {
+            if(result.get(i) instanceof Double) assertTrue(result.get(i) == expected.get(i));
+            else if(result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i),(byte[])expected.get(i)));
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+        //assertEquals("Vector(Map(Store -> 1000), 1000)", result.toString());
+    }
+
+    @Test
+    public void ExtractWhenKeyIsInsideKey_V5() {
+        BsonObject obj3 = new BsonObject().put("Store", new BsonArray());
+        BsonArray arr2 = new BsonArray().add(obj3);
+        BsonObject obj2 = new BsonObject().put("NotStore", arr2);
+        BsonArray arr1 = new BsonArray().add(obj2);
+        BsonObject obj1 = new BsonObject().put("Store", arr1);
+        String expression = "..Store[@Store]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(obj1.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>)future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+
+
+        assert(result.size() == expected.size());
+        for(int i =0;i<result.size();i++) {
+            if(result.get(i) instanceof Double) assertTrue(result.get(i) == expected.get(i));
+            else if(result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i),(byte[])expected.get(i)));
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+        //assertEquals("Vector(Map(Store -> 1000), 1000)", result.toString());
+    }
+
+    @Test
+    public void ExtractWhenKeyIsInsideKey_V6() {
+        BsonObject obj3 = new BsonObject().put("Store", new BsonArray());
+        BsonArray arr2 = new BsonArray().add(obj3);
+        BsonObject obj2 = new BsonObject().put("NotStore", arr2);
+        BsonArray arr1 = new BsonArray().add(obj2);
+        BsonObject obj1 = new BsonObject().put("Store", arr1);
+        String expression = ".Store[@Store]";
+        CompletableFuture<BsValue> future1 = new CompletableFuture<>();
+        Boson boson = Boson.extractor(expression, future1::complete);
+        boson.go(obj1.encodeToBarray());
+
+        scala.collection.immutable.Vector<Object> res = (scala.collection.immutable.Vector<Object>)future1.join().getValue();
+        List<Object> result = scala.collection.JavaConverters.seqAsJavaList(res);
+        List<Object> expected = new ArrayList<>();
+
+
+        assert(result.size() == expected.size());
+        for(int i =0;i<result.size();i++) {
+            if(result.get(i) instanceof Double) assertTrue(result.get(i) == expected.get(i));
+            else if(result.get(i) instanceof byte[] && expected.get(i) instanceof byte[])
+                assertTrue(Arrays.equals((byte[]) result.get(i),(byte[])expected.get(i)));
+            else assertTrue(result.get(i).equals(expected.get(i)));
+        }
+        //assertEquals("Vector(Map(Store -> 1000), 1000)", result.toString());
+    }
 
 }

--- a/src/test/scala/io/boson/APIwithByteBufferTests.scala
+++ b/src/test/scala/io/boson/APIwithByteBufferTests.scala
@@ -36,16 +36,23 @@ class APIwithByteBufferTests extends FunSuite{
 
 
   test("extract PosV1 w/ key") {
+    println(arr)
     val expression: String = "[2 to 3]"
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val boson: Boson = Boson.extractor(expression, (in: BsValue) => future.complete(in))
     boson.go(validatedByteBuffer)
 
-    val expected: Vector[Array[Byte]] = Vector(arr.getBsonObject(2).encodeToBarray(),arr.getBsonObject(3).encodeToBarray())
-    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    val expected: Vector[Any] = Vector(obj2.encodeToBarray(),obj3.encodeToBarray(), br4.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Any]]
+    println(s"result: $result")
     assert(expected.size === result.size)
-    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-  } //TODO: This test should return 1 more objects
+    assertTrue(expected.zip(result).forall{
+      case (e: Array[Byte], r: Array[Byte]) =>
+        println(s"e: $e, r: $r, are they equal? ${e.sameElements(r)}")
+        e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
 
   test("extract PosV2 w/ key") {
     val expression: String = "[2 until 3]"
@@ -53,11 +60,17 @@ class APIwithByteBufferTests extends FunSuite{
     val boson: Boson = Boson.extractor(expression, (in: BsValue) => future.complete(in))
     boson.go(validatedByteBuffer)
 
-    val expected: Vector[Array[Byte]] = Vector(arr.getBsonObject(2).encodeToBarray())
-    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    val expected: Vector[Any] = Vector(obj2.encodeToBarray(), br4.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Any]]
+    println(s"result: $result")
     assert(expected.size === result.size)
-    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-  } //TODO: This test should return 1 more objects
+    assertTrue(expected.zip(result).forall{
+      case (e: Array[Byte], r: Array[Byte]) =>
+        println(s"e: $e, r: $r, are they equal? ${e.sameElements(r)}")
+        e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
 
   test("extract PosV3 w/ key") {
     val expression: String = "[2 until end]"
@@ -65,11 +78,16 @@ class APIwithByteBufferTests extends FunSuite{
     val boson: Boson = Boson.extractor(expression, (in: BsValue) => future.complete(in))
     boson.go(validatedByteBuffer)
 
-    val expected: Vector[Array[Byte]] = Vector(arr.getBsonObject(2).encodeToBarray(),arr.getBsonObject(3).encodeToBarray())
-    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    val expected: Vector[Any] = Vector(obj2.encodeToBarray(),obj3.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Any]]
     assert(expected.size === result.size)
-    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-  } //TODO: This test should return 1 more objects
+    assertTrue(expected.zip(result).forall{
+      case (e: Array[Byte], r: Array[Byte]) =>
+        println(s"e: $e, r: $r, are they equal? ${e.sameElements(r)}")
+        e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
 
   test("extract PosV4 w/ key") {
     val expression: String = "[2 to end]"
@@ -77,14 +95,14 @@ class APIwithByteBufferTests extends FunSuite{
     val boson: Boson = Boson.extractor(expression, (in: BsValue) => future.complete(in))
     boson.go(validatedByteBuffer)
 
-    val expected: Vector[Any] = Vector(arr.getBsonObject(2).encodeToBarray(),arr.getBsonObject(3).encodeToBarray(),br4.encodeToBarray())
+    val expected: Vector[Any] = Vector(obj2.encodeToBarray(),obj3.encodeToBarray(),br4.encodeToBarray(),br4.encodeToBarray())
     val result = future.join().getValue.asInstanceOf[Vector[Any]]
     assert(expected.size === result.size)
     assertTrue(expected.zip(result).forall{
       case (e: Array[Byte],r: Array[Byte]) => e.sameElements(r)
       case (e,r) => e.equals(r)
     })
-  } //TODO: This test should return 1 more objects
+  }
 
   test("extract PosV5 w/ key") {
     val expression: String = "[3]"
@@ -92,7 +110,7 @@ class APIwithByteBufferTests extends FunSuite{
     val boson: Boson = Boson.extractor(expression, (in: BsValue) => future.complete(in))
     boson.go(validatedByteBuffer)
 
-    val expected: Vector[Array[Byte]] = Vector(arr.getBsonObject(3).encodeToBarray())
+    val expected: Vector[Array[Byte]] = Vector(obj3.encodeToBarray())
     val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
     assert(expected.size === result.size)
     assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))

--- a/src/test/scala/io/boson/ExtractorTests.scala
+++ b/src/test/scala/io/boson/ExtractorTests.scala
@@ -70,7 +70,7 @@ class ExtractorTests extends FunSuite {
     val bosonBson: BosonImpl = new BosonImpl(byteArray = Option(globalObj.encode().getBytes()))
     help.writeBytes(bosonBson.extract(bosonBson.getByteBuf, List(("FavoriteSentence","first")), List((None,None,""))).get.asInstanceOf[Vector[Any]].head.asInstanceOf[String].getBytes)
     finalBuf.writeBytes(io.netty.handler.codec.base64.Base64.decode(help))
-    assert("Be the best".getBytes === new String(finalBuf.array()).replaceAll("\\p{C}", "").getBytes) //TODO:eliminate replaceAll from here
+    assert("Be the best".getBytes === new String(finalBuf.array()).replaceAll("\\p{C}", "").getBytes)
   }
 
   test("Extract Array[Byte] w/ String") {

--- a/src/test/scala/io/boson/HorribleTests.scala
+++ b/src/test/scala/io/boson/HorribleTests.scala
@@ -1,5 +1,6 @@
 package io.boson
 
+import java.nio.ByteBuffer
 import java.util.concurrent.CompletableFuture
 
 import bsonLib.{BsonArray, BsonObject}
@@ -11,7 +12,7 @@ import io.boson.bson.bsonPath.{Interpreter, Program, TinyLanguage}
 import io.boson.bson.bsonValue.{BsException, BsSeq, BsValue}
 import io.boson.bson.{Boson, bsonValue}
 import io.netty.util.ResourceLeakDetector
-import org.junit.Assert.{assertEquals,assertTrue}
+import org.junit.Assert.{assertEquals, assertTrue}
 
 /**
   * Created by Tiago Filipe on 25/10/2017.
@@ -343,5 +344,19 @@ class HorribleTests extends FunSuite {
       BsException("Failure parsing!"),
       future.join())
   }
+
+  test("Empty buf") {
+    val buf: ByteBuffer = ByteBuffer.allocate(0)
+    val expression = "..Store"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(buf)
+
+    assertEquals(
+      BsException("java.lang.IndexOutOfBoundsException"),
+      future.join())
+  }
+
+
 
 }

--- a/src/test/scala/io/boson/LanguageTests.scala
+++ b/src/test/scala/io/boson/LanguageTests.scala
@@ -249,42 +249,44 @@ class LanguageTests extends FunSuite {
     val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(boson, expression)
 
-    val expected: Vector[Any] = Vector(obj4.encodeToBarray(), "Temperature")
+    val expected: Vector[Any] = Vector(obj4.encodeToBarray(), "Temperature", obj2.encodeToBarray(), obj3.encodeToBarray(), "Null", 100L, 2.3f, false)
     val res = resultParser.getValue.asInstanceOf[Vector[Any]]
     assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall{
+      case (e,r: Double) => e == r
+      case (e,r) if e == null && r == null => true
       case (e: Array[Byte],r: Array[Byte]) => e.sameElements(r)
       case (e,r) => e.equals(r)
     })
-  } //TODO: This test should return more results
+  }
 
   test("[# to #] w/key") {
     val expression: String = "[1 to 1]"
     val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(boson, expression)
 
-    val expected: Vector[Any] = Vector(obj4.encodeToBarray())
+    val expected: Vector[Any] = Vector(obj4.encodeToBarray(), obj2.encodeToBarray())
     val res = resultParser.getValue.asInstanceOf[Vector[Any]]
     assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall{
       case (e: Array[Byte],r: Array[Byte]) => e.sameElements(r)
       case (e,r) => e.equals(r)
     })
-  } //TODO: This test should return more results
+  }
 
   test("[# until #] w/key") {
     val expression: String = "[1 until 2]"
     val boson: BosonImpl = new BosonImpl(byteArray = Option(arrEvent.encode().getBytes))
     val resultParser: BsValue = callParse(boson, expression)
 
-    val expected: Vector[Any] = Vector(obj4.encodeToBarray())
+    val expected: Vector[Any] = Vector(obj4.encodeToBarray(), obj2.encodeToBarray())
     val res = resultParser.getValue.asInstanceOf[Vector[Any]]
     assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall{
       case (e: Array[Byte],r: Array[Byte]) => e.sameElements(r)
       case (e,r) => e.equals(r)
     })
-  } //TODO: This test should return more results
+  }
 
 
 

--- a/src/test/scala/io/boson/LanguageTests.scala
+++ b/src/test/scala/io/boson/LanguageTests.scala
@@ -191,11 +191,18 @@ class LanguageTests extends FunSuite {
   }
 
 
-  test(".[#to#].[#].[#]") {
+  test(".[#to#].[#].[#] No Output") {
     val expression: String = ".[5 to 7].[1].[0]"
     val boson: BosonImpl = new BosonImpl(byteArray = Option(arr1.encode().getBytes))
     val result: BsValue = callParse(boson, expression)
     assertEquals(BsSeq(Vector()), result)
+  }
+
+  test(".[#to#].[#].[#]") {
+    val expression: String = ".[5 to 7].[0]"
+    val boson: BosonImpl = new BosonImpl(byteArray = Option(arr1.encode().getBytes))
+    val result: BsValue = callParse(boson, expression)
+    assertEquals(BsSeq(Vector("Null")), result)
   }
 
   test(".[#toend].[#].[#]") {

--- a/src/test/scala/io/boson/injectorAPITests.scala
+++ b/src/test/scala/io/boson/injectorAPITests.scala
@@ -25,7 +25,7 @@ class injectorAPITests extends FunSuite {
   val b10: BsonObject = new BsonObject().put("Title","JavaMachine").put("Price", 39)
   val br4: BsonArray = new BsonArray().add(b10)
   val b9: BsonObject = new BsonObject().put("Title","ScalaMachine").put("Price", 40)
-  val br3: BsonArray = new BsonArray().add(b9)//.add(new BsonObject().put("Ti","shit"))
+  val br3: BsonArray = new BsonArray().add(b9)
   val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
   val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
   val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
@@ -148,12 +148,18 @@ class injectorAPITests extends FunSuite {
     val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
     boson.go(validatedByteArr)
 
-    val expected: Vector[Array[Byte]] =
-      Vector(br1.getBsonObject(0).encodeToBarray(),br1.getBsonObject(2).encodeToBarray(), b5.encodeToBarray(), b6.encodeToBarray(), b7.encodeToBarray())
-    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    val expected: Vector[Any] =
+      Vector(b3.encodeToBarray(),b10.encodeToBarray(), b9.encodeToBarray(), b8.encodeToBarray(), b11.encodeToBarray(), b5.encodeToBarray(), b6.encodeToBarray(), b7.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Any]]
+    println(s"result: $result")
     assert(expected.size === result.size)
-    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-  } //TODO: This test should return 3 more objects
+    assertTrue(expected.zip(result).forall {
+      case (e: Array[Byte], r: Array[Byte]) =>
+        println(s"e: $e, r: $r, are they equal? ${e.sameElements(r)}")
+        e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
 
   test("extract *[@*elem]") {
     val expression = "*[@*ce]"
@@ -162,11 +168,11 @@ class injectorAPITests extends FunSuite {
     boson.go(validatedByteArr)
 
     val expected: Vector[Array[Byte]] =
-      Vector(br1.getBsonObject(0).encodeToBarray(),br1.getBsonObject(2).encodeToBarray(), b5.encodeToBarray(), b6.encodeToBarray(), b7.encodeToBarray())
+      Vector(b3.encodeToBarray(),b10.encodeToBarray(), b9.encodeToBarray(), b8.encodeToBarray(), b11.encodeToBarray(), b5.encodeToBarray(), b6.encodeToBarray(), b7.encodeToBarray())
     val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
     assert(expected.size === result.size)
     assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-  } //TODO: This test should return 3 more objects
+  }
 
   test("extract Key.Key.Key") {
     val expression = "Store.Book.Title"

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -2634,4 +2634,208 @@ class jpPlusPlusTests extends FunSuite {
     })
   }
 
+  test("Ex Coverage of expression [#]..[#]") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(false)).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = "[1 to end]..[all]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(2)
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 1") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = "This.*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(true, new BsonArray().add(1).encodeToBarray(), new BsonObject().encodeToBarray(), new BsonArray().add(2).encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 2") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = "This.*.*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(1,2)
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 3") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = "This.*..field[@elem]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector()
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 4") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = "This[0 to end].*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(true, new BsonArray().add(1).encodeToBarray(),new BsonObject().encodeToBarray(),new BsonArray().add(2).encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 5") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = ".This[0 to end].[1 to end].*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector()
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 6") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = ".This[0 to end].[end].*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector()
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 7") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = ".This[end].*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(new BsonObject().encodeToBarray() ,new BsonArray().add(2).encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 8") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = ".This[end].*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(true,new BsonArray().add(1).encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 9") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = ".This[0 to 1].*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(true,new BsonArray().add(1).encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 10") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = ".This[0 to 1].*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(1,2)
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 11") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = "This[0 to 1]..field[@elem]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector()
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
 }

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -2838,4 +2838,72 @@ class jpPlusPlusTests extends FunSuite {
     })
   }
 
+  test("Ex Coverage of expression .* on Arrays case 12") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1)))//.add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = ".This[end].*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(1)
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression .* on Arrays case 13") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1)))//.add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = ".This[0 to end].*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(1)
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression [end] on Arrays case 1") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = "[end].[0]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(1)
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex Coverage of expression [end] on Arrays case 2") {
+    val arr: BsonArray = new BsonArray().add(new BsonArray().add(true).add(new BsonArray().add(1))).add(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)))
+    val obj: BsonObject = new BsonObject().put("This", arr)
+    val expression: String = "[end]..[0]..[all]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj.encodeToBarray())
+
+    val expected: Vector[Any] = Vector()
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
 }

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -2218,10 +2218,10 @@ class jpPlusPlusTests extends FunSuite {
   test("Ex [# to end]..Key1") {
     val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
     val br5: BsonArray = new BsonArray().add(b11)
-    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39)
+    val b10: BsonObject = new BsonObject().put("SpecialEditions", br5).put("Title", "JavaMachine").put("Price", 39)
     val br4: BsonArray = new BsonArray().add(b10)
     val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
-    val br3: BsonArray = new BsonArray().add(b9)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
     val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
     val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
     val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
@@ -2239,14 +2239,19 @@ class jpPlusPlusTests extends FunSuite {
     boson.go(bsonEvent.encodeToBarray())
 
     val expected: Vector[Any] = Vector(
+      b11.encodeToBarray(),
       b10.encodeToBarray(),
       b9.encodeToBarray(),
+      b11.encodeToBarray(),
+      b10.encodeToBarray(),
+      b11.encodeToBarray(),
+      b11.encodeToBarray(),
       b11.encodeToBarray(),
       b10.encodeToBarray()
     )
     val res = future.join().getValue.asInstanceOf[Vector[Any]]
     println(s"res: $res")
-    //assert(expected.size === res.size)
+    assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall {
       case (e: Array[Byte], r: Array[Byte]) =>
         println(s"e: $e, r: $r, are they equal? ${e.sameElements(r)}")

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -17,7 +17,7 @@ import org.scalatest.junit.JUnitRunner
 import org.junit.Assert._
 
 @RunWith(classOf[JUnitRunner])
-class jpPlusPlusTests extends FunSuite{
+class jpPlusPlusTests extends FunSuite {
   ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.ADVANCED)
   val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
   val br5: BsonArray = new BsonArray().add(b11)
@@ -55,2013 +55,2061 @@ class jpPlusPlusTests extends FunSuite{
 
   val validatedByteArr: Array[Byte] = bsonEvent.encodeToBarray()
 
-    test("Ex .key"){
-      println(bsonEvent)
-      val expression = ".Store"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b2.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.Store -> checked
-
-    test("Inj .key"){
-      val expression: String = ".Store"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if (res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val bosonE: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      bosonE.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] = Vector(_b2.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .key1.key2"){
-      val expression = ".Store.Book"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-
-      val expected: Vector[Array[Byte]] = Vector(br1.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.Store.Book -> checked
-
-    test("Inj .key1.key2"){
-      val expression: String = ".Store.Book"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("Street?"))
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val l: List[Any] = Mapper.decodeBsonArray(b.getByteBuf)
-        val newL: List[Any] = l.+:("Street?")
-        val res: ByteBuf = Mapper.encode(newL)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-      val help: BsonArray = new BsonArray().add("Street?").add(_b3).add(_b4).add(_b8)
-
-      val expected: Vector[Array[Byte]] = Vector(help.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .key1.key2[@elem1].key3[@elem2]"){
-      val expression: String = ".Store.Book[@Price].SpecialEditions[@Title]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b11.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.Store.Book[?(@.Price)].SpecialEditions[?(@.Title)] -> checked
-
-    test("Inj .key1.key2[@elem1].key3[@elem2]"){
-      val expression: String = ".Store.Book[@Price].SpecialEditions[@Title]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] = Vector(_b10.put("Street?", "im Lost").encodeToBarray(),_b11.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .key1.key2[#]"){
-      val expression: String = ".Store.Book[1]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b4.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.Store.Book[1] -> checked
-
-    test("Inj .key1.key2[#]"){
-      val expression: String = ".Store.Book[1]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] = Vector(_b4.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .key1.key2[# to end].key3"){
-      val expression: String = ".Store.Book[0 to end].Price"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      assertEquals(Vector(
-        15.5, 12.6
-      ), future.join().getValue)
-    } //$.Store.Book[:].Price -> checked
-
-    test("Inj .key1.key2[# to end].key3"){
-      val expression: String = ".Store.Book[0 to end].Price"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Double) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(25.5, 22.6)", future.join().getValue.toString)
-    }
-
-    test("Ex .key1.key2[@elem].key3"){
-      val expression: String = ".Store.Book[@Price].Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      assertEquals(Vector(
-        "Java", "C++"
-      ), future.join().getValue)
-    } //$.Store.Book[?(@.Price)].Title -> checked
-
-    test("Inj .key1.key2[@elem].key3"){
-      val expression: String = ".Store.Book[@Price].Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Java!!!, C++!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex .key1.key2[#].key3[@elem].k*y"){
-      val expression: String = ".Store.Book[0 to end].SpecialEditions[@Price].T*le"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "JavaMachine", "ScalaMachine", "C++Machine"
-      ), future.join().getValue)
-    } //$.Store.Book[:].SpecialEditions[?(@.Price)].Title -> checked
-
-    //-----------------------------------------------------------------------------------------------------//
-
-    test("Inj .key1.key2[#].key3[@elem].k*y"){
-      val expression: String = ".Store.Book[0 to end].SpecialEditions[@Price].T*le"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(JavaMachine!!!, ScalaMachine!!!, C++Machine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key V1"){
-      val expression: String = "..Title" // || "Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      assertEquals(Vector(
-        "Java", "JavaMachine", "Scala", "ScalaMachine", "C++", "C++Machine", "Java", "JavaMachine"
-      ), future.join().getValue)
-    } //$..Title -> checked
-
-    test("Inj ..key V1"){
-      val expression: String = "..Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Java!!!, JavaMachine!!!, Scala!!!, ScalaMachine!!!, C++!!!, C++Machine!!!, Java!!!, JavaMachine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key V2"){
-      val expression: String = "..Price"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      assertEquals(Vector(
-        15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39
-      ), future.join().getValue)
-    } //$..Price -> checked
-
-    test("Inj ..key V2"){
-      val expression: String = "..Book.*.Price"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Double) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(25.5, 22.6)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1.key2"){
-      val expression: String = "..Book.Title" //  || "Book.Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      assertEquals(Vector(
-        "Java", "Scala", "C++"
-      ), future.join().getValue)
-    } //$..Book[:].Title -> checked
-
-    test("Inj ..key1.key2"){
-      val expression: String = "..Book.Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Java, Scala, C++)", future.join().getValue.toString)
-    } //No change is perform, because Book is a Array.
-
-    test("Ex ..key1[# to end].key2"){
-      val expression: String = "..Book[0 to end].Price"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      assertEquals(Vector(
-        15.5, 12.6
-      ), future.join().getValue)
-    } //$..Book[:].Price -> checked
-
-    test("Inj ..key1[# to end].key2"){
-      val expression: String = "..Book[0 to end].Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Java!!!, Scala!!!, C++!!!)", future.join().getValue.toString)
-    } //Change is perform, because Book is a Array.
-
-    test("Ex ..key[@elem].key"){
-      val expression: String = "..SpecialEditions[@Price].Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "JavaMachine", "ScalaMachine", "C++Machine", "JavaMachine"
-      ), future.join().getValue)
-    } //$..SpecialEditions[?(@.Price)].Title -> checked
-
-    test("Inj ..key[@elem].key"){
-      val expression: String = "..SpecialEditions[@Price].Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(JavaMachine!!!, ScalaMachine!!!, C++Machine!!!, JavaMachine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key[@elem]"){
-      val expression: String = "..SpecialEditions[@Price]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray(),b10.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$..SpecialEditions[?(@.Price)] -> checked
-
-    test("Inj ..key[@elem]"){
-      val expression: String = "..SpecialEditions[@Price]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-       val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-       val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-       val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-       val res: ByteBuf = Mapper.encode(newM)
-       if(res.hasArray)
-         res.array()
-       else {
-         val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-         val array: Array[Byte] = buf.array()
-         buf.release()
-         array
-       }
-     })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(_b10.put("Street?", "im Lost").encodeToBarray(),_b9.put("Street?", "im Lost").encodeToBarray(),_b11.put("Street?", "im Lost").encodeToBarray(),_b10.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..key[#] V1"){
-      val expression: String = "..SpecialEditions[0]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray(),b10.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$..SpecialEditions[0] -> checked
-
-    test("Inj ..key[#] V1"){
-      val expression: String = "..SpecialEditions[0]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(_b10.put("Street?", "im Lost").encodeToBarray(),_b9.put("Street?", "im Lost").encodeToBarray(),_b11.put("Street?", "im Lost").encodeToBarray(),_b10.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))    }
-
-    test("Ex ..key[#] V2"){
-      val arr5: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 12))
-      val arr4: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 18))
-      val arr3: BsonArray = new BsonArray().add(new BsonObject().put("doorOpen", arr5))
-      val arr2: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 15))
-      val obj1: BsonObject = new BsonObject().put("fridgeTemp", 5.2f).put("fanVelocity", 20.5).put("doorOpen", arr2)
-      val obj2: BsonObject = new BsonObject().put("fridgeTemp", 5.0f).put("fanVelocity", 20.6).put("thing", arr3)
-      val obj3: BsonObject = new BsonObject().put("fridgeTemp", 3.854f).put("fanVelocity", 20.5).put("doorOpen", arr4)
-      val arr: BsonArray = new BsonArray().add(obj1).add(obj2).add(obj3)
-      val bsonEvent: BsonObject = new BsonObject().put("fridgeReadings", arr)
-
-      val expression: String = "..doorOpen[0]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(bsonEvent.encodeToBarray())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(
-          new BsonObject().put("fridgeTemp", 15).encodeToBarray(),
-          new BsonObject().put("fridgeTemp", 12).encodeToBarray(),
-          new BsonObject().put("fridgeTemp", 18).encodeToBarray()
-        )
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj ..key[#] V2"){
-      val arr5: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 12))
-      val arr4: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 18))
-      val arr3: BsonArray = new BsonArray().add(new BsonObject().put("doorOpen", arr5))
-      val arr2: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 15))
-      val obj1: BsonObject = new BsonObject().put("fridgeTemp", 5.2f).put("fanVelocity", 20.5).put("doorOpen", arr2)
-      val obj2: BsonObject = new BsonObject().put("fridgeTemp", 5.0f).put("fanVelocity", 20.6).put("thing", arr3)
-      val obj3: BsonObject = new BsonObject().put("fridgeTemp", 3.854f).put("fanVelocity", 20.5).put("doorOpen", arr4)
-      val arr: BsonArray = new BsonArray().add(obj1).add(obj2).add(obj3)
-      val bsonEvent: BsonObject = new BsonObject().put("fridgeReadings", arr)
-
-      val expression: String = "..doorOpen[0]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(bsonEvent.encodeToBarray())
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(new BsonObject().put("fridgeTemp", 15).put("Street?", "im Lost").encodeToBarray(),new BsonObject().put("fridgeTemp", 12).put("Street?", "im Lost").encodeToBarray(),new BsonObject().put("fridgeTemp", 18).put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..*y1[@elem1].key2[@elem2]"){
-      val expression: String = "..*k[@Price].SpecialEditions[@Price]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b11.encodeToBarray(),b10.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$..Book[?(@.Price)].SpecialEditions[?(@.Price)] && $..Hatk[?(@.Price)].SpecialEditions[?(@.Price)] -> checked
-
-    test("Inj ..*y1[@elem1].key2[@elem2]"){
-      val expression: String = "..*k[@Price].SpecialEditions[@Price]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(_b10.put("Street?", "im Lost").encodeToBarray(),_b11.put("Street?", "im Lost").encodeToBarray(),_b10.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..*y1[@elem1].key2"){
-      val expression: String = "..*k[@SpecialEditions].Pr*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        15.5, 21.5, 12.6, 15.5
-      ), future.join().getValue)
-    } //$..Book[?(@.SpecialEditions)].Price && $..Hatk[?(@.SpecialEditions)].Price -> checked
-
-    //---------------------------------------------------------------------------------------------------//
-
-    test("Inj ..*y1[@elem1].key2"){
-      val expression: String = "..*k[@SpecialEditions].Pr*"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Double) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(25.5, 31.5, 22.6, 25.5)", future.join().getValue.toString)
-    }
-
-    test("Ex .key1..key2"){
-      val expression: String = ".Store..Price"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39
-      ), future.join().getValue)
-    } //$.Store..Price -> checked
-
-    test("Inj .key1..key2"){
-      //No Change is perform, because not all values are of the same type
-      val expression: String = ".Store..Price"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Double) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39)", future.join().getValue.toString)
-    } //No Change is perform, because not all values are of the same type
-
-    test("Ex .key1..key2[@elem]"){
-      val expression: String = ".Store..SpecialEditions[@Price]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray(),b10.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.Store..SpecialEditions[?(@.Price)] -> checked
-
-    test("Inj .key1..key2[@elem]"){
-      //No Change is perform, because not all values are of the same type
-      val expression: String = ".Store..SpecialEditions[@Price]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(_b10.put("Street?", "im Lost").encodeToBarray(),_b9.put("Street?", "im Lost").encodeToBarray(),_b11.put("Street?", "im Lost").encodeToBarray(),_b10.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .key1..key2[#]"){
-      val expression: String = ".Store..SpecialEditions[0]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray(),b10.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.Store..SpecialEditions[0] -> checked
-
-    test("Inj .key1..key2[#]"){
-      //No Change is perform, because not all values are of the same type
-      val expression: String = ".Store..SpecialEditions[0]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(_b10.put("Street?", "im Lost").encodeToBarray(),_b9.put("Street?", "im Lost").encodeToBarray(),_b11.put("Street?", "im Lost").encodeToBarray(),_b10.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .key1..key2[#]..key3"){
-      val expression: String = ".Store..Book[0 until end]..Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "Java",
-        "JavaMachine",
-        "Scala",
-        "ScalaMachine"
-      ), future.join().getValue)
-    } //$.Store..Book[0:2]..Title -> checked
-
-    test("Inj .key1..key2[#]..key3"){
-      val expression: String = ".Store..Book[0 until end]..Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Java!!!, JavaMachine!!!, Scala!!!, ScalaMachine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex .key1..key2[#]..key3[@elem]"){
-      val expression: String = ".Store..Book[1 until end]..SpecialEditions[@Price]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b9.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.Store..Book[1:2]..SpecialEditions[?(@.Price)] -> checked
-
-    test("Inj .key1..key2[#]..key3[@elem]"){
-      val expression: String = ".Store..Book[1 until end]..SpecialEditions[@Price]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-      //println("injFuture=" + new String(injFuture.join()))
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(_b9.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .*y1..*y2[#]..*y3..key4"){
-      val expression: String = ".*ore..*k[1 until end]..*Editions..Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector("ScalaMachine"), future.join().getValue)
-    } //$.Store..Book[1:2]..SpecialEditions..Title -> checked
-
-    test("Inj .*y1..*y2[#]..*y3..key4"){
-      val expression: String = ".*ore..*k[1 until end]..*Editions..Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-      //println("injFuture=" + new String(injFuture.join()))
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(ScalaMachine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex .key1..key2[@elem1]..key3[@elem2]"){
-      val expression: String = ".Store..*k[@Price]..SpecialEditions[@Title]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b11.encodeToBarray(),b10.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.Store..Book[?(@.Price)]..SpecialEditions[?(@.Title)] && $.Store..Hatk[?(@.Price)]..SpecialEditions[?(@.Title)] -> checked
-
-    //---------------------------------------------------------------------------------------------------//
-
-    test("Inj .key1..key2[@elem1]..key3[@elem2]"){
-      val expression: String = ".Store..*k[@Price]..SpecialEditions[@Title]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(_b10.put("Street?", "im Lost").encodeToBarray(),_b11.put("Street?", "im Lost").encodeToBarray(),_b10.put("Street?", "im Lost").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))    }
-
-    test("Ex ..key1[#]..key2"){
-      val expression: String = "..Book[0 to end]..Price"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        15.5, 39, 40, 12.6, 38
-      ), future.join().getValue)
-    } //$..Book[:]..Price -> checked
-
-    test("Inj ..key1[#]..key2"){
-      val expression: String = "..Book[0 to end]..Price"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-      //println("injFuture=" + new String(injFuture.join()))
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(15.5, 39, 40, 12.6, 38)", future.join().getValue.toString)
-    } //No Change is perform, because not all values are of the same type
-
-    test("Ex ..key1..key2"){
-      val expression: String = "Store..Price"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39
-      ), future.join().getValue)
-    } //$..Store..Price -> checked
-
-    test("Inj ..key1..key2"){
-      val expression: String = "Store..Price"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-     // println("injFuture=" + new String(injFuture.join()))
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39)", future.join().getValue.toString)
-    } //No Change is perform, because not all values are of the same type
-
-    test("Ex ..key1[@elem]..key2"){
-      val expression: String = "Book[@Price]..Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "Java", "JavaMachine", "C++", "C++Machine"
-      ), future.join().getValue)
-    } //$..Book[?(@.Price)]..Title -> checked
-
-    test("Inj ..key1[@elem]..key2"){
-      val expression: String = "Book[@Price]..Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Java!!!, JavaMachine!!!, C++!!!, C++Machine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1..*ey2..*ey3"){
-      val expression: String = "Store..*k..*itions"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      val expected: Vector[Array[Byte]] = Vector(br4.encodeToBarray(), br3.encodeToBarray(), br5.encodeToBarray(), br4.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$..Store..Book..SpecialEditions && $..Store..Hatk..SpecialEditions -> checked
-
-    test("Inj ..key1..*ey2..*ey3"){
-      val expression: String = "Store..*k..*itions"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("NewEdition!"))
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val l: List[Any] = Mapper.decodeBsonArray(b.getByteBuf)
-        val newL: List[Any] = l.:+("NewEdition!")
-        val res: ByteBuf = Mapper.encode(newL)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-     // println("injFuture=" + new String(injFuture.join()))
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-      val xbr4 = new BsonArray().add(new BsonObject().put("Price", 39).put("Title", "JavaMachine")).add("NewEdition!").encodeToBarray()
-      val xbr3 = new BsonArray().add(new BsonObject().put("Price", 40).put("Title", "ScalaMachine")).add("NewEdition!").encodeToBarray()
-      val xbr5 = new BsonArray().add(new BsonObject().put("Price", 38).put("Title", "C++Machine")).add("NewEdition!").encodeToBarray()
-
-      val expected: Vector[Array[Byte]] = Vector(xbr4,xbr3,xbr5,xbr4)
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..key1.key2..key3"){
-      val expression: String = "..Book.SpecialEditions..Price"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        39, 40, 38
-      ), future.join().getValue)
-    } //$..Book[:].SpecialEditions..Price -> checked
-
-    //---------------------------------------------------------------------------------------------------//
-
-    test("Inj ..key1.key2..key3"){
-      val expression: String = "..Book.SpecialEditions..Price"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(39, 40, 38)", future.join().getValue.toString)
-    } // Change is not perform because Book is an array, and the expression misses the Array specification
-
-    test("Ex .key.*"){
-      val expression: String = ".Store.*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(br1.encodeToBarray(), br2.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj .key.*"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-
-      val expression: String = ".Store.*"
-
-      //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("newField!"))
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val l: List[Any] = Mapper.decodeBsonArray(b.getByteBuf)
-        val newL: List[Any] = l.:+("newField!")
-        val res: ByteBuf = Mapper.encode(newL)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] = Vector(xbr1.add("newField!").encodeToBarray(),xbr2.add("newField!").encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..key.*"){
-      val expression: String = "SpecialEditions.*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray(),b10.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj ..key.*"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-
-      val expression: String = "SpecialEditions.*"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("newField!", 100))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(xb10.put("newField!", 100).encodeToBarray(),xb9.put("newField!", 100).encodeToBarray(),xb11.put("newField!", 100).encodeToBarray(),xb10.put("newField!", 100).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..key[#].*"){
-      val expression: String = "SpecialEditions[0 to end].*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "JavaMachine",
-        39,
-        "ScalaMachine",
-        40,
-        "C++Machine",
-        38,
-        "JavaMachine",
-        39
-      ), future.join().getValue)
-    }
-
-    test("Inj ..key[#].*"){
-      val expression: String = "SpecialEditions[0 to end].*"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(JavaMachine, 39, ScalaMachine, 40, C++Machine, 38, JavaMachine, 39)", future.join().getValue.toString)
-    } // Change is not perform because the values are not the same type
-
-    test("Ex ..key1.*.key2"){
-      val expression: String = "Book.*.Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "Java",
-        "Scala",
-        "C++"
-      ), future.join().getValue)
-    }
-
-    test("Inj ..key1.*.key2"){
-      val expression: String = "Book.*.Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Java!!!, Scala!!!, C++!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1.*..key2"){
-      val expression: String = "Book.*..Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "Java",
-        "JavaMachine",
-        "Scala",
-        "ScalaMachine",
-        "C++",
-        "C++Machine"
-      ), future.join().getValue)
-    }
-
-    test("Inj ..key1.*..key2"){
-      val expression: String = "Book.*..Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Java!!!, JavaMachine!!!, Scala!!!, ScalaMachine!!!, C++!!!, C++Machine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1[#].*.key2"){
-      val expression: String = "Book[0 to end].*.Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(), future.join().getValue)
-    }
-
-    test("Inj ..key1[#].*.key2"){
-      val expression: String = "Book[0 to end].*.Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector()", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1[#].*..key2"){
-      val expression: String = "Book[0 to end].*..Title"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "JavaMachine",
-        "ScalaMachine",
-        "C++Machine"
-      ), future.join().getValue)
-    }
-
-    test("Inj ..key1[#].*..key2"){
-      val expression: String = "Book[0 to end].*..Title"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(JavaMachine!!!, ScalaMachine!!!, C++Machine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1.*.key2[@elem]"){
-      val expression: String = "Book.*.SpecialEditions[@Price]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj ..key1.*.key2[@elem]"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-      val expression: String = "Book.*.SpecialEditions[@Price]"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(xb10.put("Street", 1000).encodeToBarray(),xb9.put("Street", 1000).encodeToBarray(),xb11.put("Street", 1000).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..key[@elem].*"){
-      val expression: String = "SpecialEditions[@Price].*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "JavaMachine",
-        39,
-        "ScalaMachine",
-        40,
-        "C++Machine",
-        38,
-        "JavaMachine",
-        39
-      ), future.join().getValue)
-    }
-
-    test("Inj ..key[@elem].*"){
-      val expression: String = "SpecialEditions[@Price].*"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(JavaMachine, 39, ScalaMachine, 40, C++Machine, 38, JavaMachine, 39)", future.join().getValue.toString)
-    } // Change is not perform because the values are not the same type
-
-    test("Ex ..key1[#].*.key2[@elem]"){
-      val expression: String = "Book[0 to end].*..SpecialEditions[@Price]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(), future.join().getValue)
-    }
-
-    test("Inj ..key1[#].*.key2[@elem]"){
-      val expression: String = "Book[0 to end].*..SpecialEditions[@Price]"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector()", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1.*.[#]"){
-      val expression: String = "Book.*.[0 to end]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(), future.join().getValue)
-    }
-
-    test("Inj ..key1.*.[#]"){
-      val expression: String = "Book.*.[0 to end]"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector()", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1[#].*.[#]"){
-      val expression: String = "Book[0 to end].*.[0 to end]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj ..key1[#].*.[#]"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-      val expression: String = "Book[0 to end].*.[0 to end]"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(xb10.put("Street", 1000).encodeToBarray(),xb9.put("Street", 1000).encodeToBarray(),xb11.put("Street", 1000).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..key1[#].*..[#]"){
-      val expression: String = "Book[0 to end].*..[0 to end]"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj ..key1[#].*..[#]"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-      val expression: String = "Book[0 to end].*..[0 to end]"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(xb10.put("Street", 1000).encodeToBarray(),xb9.put("Street", 1000).encodeToBarray(),xb11.put("Street", 1000).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..key1[#].*..[#]..k*y2"){
-      val expression: String = "Book[0 to end].*..[0 to end]..Ti*e"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        "JavaMachine",
-        "ScalaMachine",
-        "C++Machine"
-      ), future.join().getValue)
-    }
-
-    test("Inj ..key1[#].*..[#]..k*y2"){
-      val expression: String = "Book[0 to end].*..[0 to end]..Ti*e"
-
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(JavaMachine!!!, ScalaMachine!!!, C++Machine!!!)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1[#].*.[#].key2"){
-      val expression: String = "Book[0 to end].*..[0 to end].Price"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      assertEquals(Vector(
-        39, 40, 38
-      ), future.join().getValue)
-    }
-
-    test("Inj ..key1[#].*.[#].key2"){
-      val expression: String = "Book[0 to end].*..[0 to end].Price"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(49, 50, 48)", future.join().getValue.toString)
-    }
-
-    test("Ex ..key1[#].*.*"){
-      val expression: String = "Book[0 to end].*.*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj ..key1[#].*.*"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-      val expression: String = "Book[0 to end].*.*"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(xb10.put("Street", 1000).encodeToBarray(),xb9.put("Street", 1000).encodeToBarray(),xb11.put("Street", 1000).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex ..key1.*.*"){
-      val expression: String = "Book.*.*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Any] = Vector("Java",15.5,br4.encodeToBarray(),"Scala",21.5,br3.encodeToBarray(),"C++",12.6,br5.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Any]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall{
-        case (e: Array[Byte],r: Array[Byte]) => e.sameElements(r)
-        case (e,r) => e.equals(r)
-      })
-    }
-
-    test("Inj ..key1.*.*"){
-      val expression: String = "Book.*.*"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Any] = Vector("Java",15.5,br4.encodeToBarray(),"Scala",21.5,br3.encodeToBarray(),"C++",12.6,br5.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Any]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall{
-        case (e: Array[Byte],r: Array[Byte]) => e.sameElements(r)
-        case (e,r) => e.equals(r)
-      })    } // Change is not perform because the values are not the same type
-
-    test("Ex .key1.*.*"){
-      val expression: String = "Store.*.*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b3.encodeToBarray(),b4.encodeToBarray(),b8.encodeToBarray(),b5.encodeToBarray(),b6.encodeToBarray(),b7.encodeToBarray(),b3.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj .key1.*.*"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-      val expression: String = "Store.*.*"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(xb3.put("Street", 1000).encodeToBarray(),xb4.put("Street", 1000).encodeToBarray(),xb8.put("Street", 1000).encodeToBarray(), xb5.put("Street", 1000).encodeToBarray(),xb6.put("Street", 1000).encodeToBarray(),xb7.put("Street", 1000).encodeToBarray(), xb3.put("Street", 1000).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .key1.*.*.*.*"){
-      val expression: String = "Store.*.*.*.*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-      val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(),b9.encodeToBarray(),b11.encodeToBarray(),b10.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Inj .key1.*.*.*.*"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-      val expression: String = "Store.*.*.*.*"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(xb10.put("Street", 1000).encodeToBarray(),xb9.put("Street", 1000).encodeToBarray(),xb11.put("Street", 1000).encodeToBarray(),xb10.put("Street", 1000).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-    test("Ex .*"){
-      val expression: String = ".*"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(validatedByteArr)
-
-      val expected: Vector[Array[Byte]] = Vector(b2.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    } //$.* -> checked
-
-    test("Inj .*"){
-      val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
-      val xbr5: BsonArray = new BsonArray().add(xb11)
-      val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
-      val xbr4: BsonArray = new BsonArray().add(xb10)
-      val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
-      val xbr3: BsonArray = new BsonArray().add(xb9)
-      val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
-      val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
-      val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
-      val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
-      val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
-      val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
-      val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
-      val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
-      val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
-      val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
-      val expression: String = ".*"
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      val expected: Vector[Array[Byte]] =
-        Vector(xb2.put("Street", 1000).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
-
-//    test("Ex ..*"){
-//      val expression: String = "..*"
-//      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-//      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-//      boson.go(validatedByteArr)
-//
-//      assertEquals(Vector(
-//        Map("Book" -> Seq(Map("Title" -> "Java", "Price" -> 15.5, "SpecialEditions" -> Seq(Map("Title" -> "JavaMachine", "Price" -> 39))),
-//          Map("Title" -> "Scala", "Pri" -> 21.5, "SpecialEditions" -> Seq(Map("Title" -> "ScalaMachine", "Price" -> 40))),
-//          Map("Title" -> "C++", "Price" -> 12.6, "SpecialEditions" -> Seq(Map("Title" -> "C++Machine", "Price" -> 38)))),
-//          "Hatk" -> Seq(Map("Color" -> "Red", "Price" -> 48), Map("Color" -> "White", "Price" -> 35), Map("Color" -> "Blue", "Price" -> 38),
-//            Map("Title" -> "Java", "Price" -> 15.5, "SpecialEditions" -> Seq(Map("Title" -> "JavaMachine", "Price" -> 39)))))
-//      ), future.join().getValue)
-//    } //TODO: Not implemented yet, so this test is wrong
-
-//    test("Inj ..* V1"){
-//      val expression: String = "..*"
-//
-//      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-//        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-//        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-//        val newM: Map[String, Any] = m.+(("Street", 1000))
-//        val res: ByteBuf = Mapper.encode(newM)
-//        if(res.hasArray)
-//          res.array()
-//        else {
-//          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-//          val array: Array[Byte] = buf.array()
-//          buf.release()
-//          array
-//        }
-//      })
-//      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-//      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-//      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-//      boson.go(injFuture.join())
-//
-//      assertEquals("Vector(Map(Book -> List(Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))), Map(Title -> Scala, Pri -> 21.5, SpecialEditions -> List(Map(Title -> ScalaMachine, Price -> 40))), Map(Title -> C++, Price -> 12.6, SpecialEditions -> List(Map(Title -> C++Machine, Price -> 38)))), Hatk -> List(Map(Color -> Red, Price -> 48), Map(Color -> White, Price -> 35), Map(Color -> Blue, Price -> 38), Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))))))", future.join().getValue.toString)
-//    } // No change is perform because the values are not the same type //TODO: Not implemented yet(extractor), so this test is wrong
-
-    /*test("Inj ..* V1"){
-      val expression: String = "..*"
-
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
-
-      assertEquals("Vector(Map(Book -> List(Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))), Map(Title -> Scala, Pri -> 21.5, SpecialEditions -> List(Map(Title -> ScalaMachine, Price -> 40))), Map(Title -> C++, Price -> 12.6, SpecialEditions -> List(Map(Title -> C++Machine, Price -> 38)))), Hatk -> List(Map(Color -> Red, Price -> 48), Map(Color -> White, Price -> 35), Map(Color -> Blue, Price -> 38), Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))))))", future.join().getValue.toString)
-    } // No change is perform because the values are not the same type*/
+  test("Ex .key") {
+    println(bsonEvent)
+    val expression = ".Store"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b2.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.Store -> checked
+
+  test("Inj .key") {
+    val expression: String = ".Store"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val bosonE: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    bosonE.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] = Vector(_b2.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .key1.key2") {
+    val expression = ".Store.Book"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+
+    val expected: Vector[Array[Byte]] = Vector(br1.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.Store.Book -> checked
+
+  test("Inj .key1.key2") {
+    val expression: String = ".Store.Book"
+
+    //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("Street?"))
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val l: List[Any] = Mapper.decodeBsonArray(b.getByteBuf)
+      val newL: List[Any] = l.+:("Street?")
+      val res: ByteBuf = Mapper.encode(newL)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+    val help: BsonArray = new BsonArray().add("Street?").add(_b3).add(_b4).add(_b8)
+
+    val expected: Vector[Array[Byte]] = Vector(help.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .key1.key2[@elem1].key3[@elem2]") {
+    val expression: String = ".Store.Book[@Price].SpecialEditions[@Title]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b11.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.Store.Book[?(@.Price)].SpecialEditions[?(@.Title)] -> checked
+
+  test("Inj .key1.key2[@elem1].key3[@elem2]") {
+    val expression: String = ".Store.Book[@Price].SpecialEditions[@Title]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] = Vector(_b10.put("Street?", "im Lost").encodeToBarray(), _b11.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .key1.key2[#]") {
+    val expression: String = ".Store.Book[1]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b4.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.Store.Book[1] -> checked
+
+  test("Inj .key1.key2[#]") {
+    val expression: String = ".Store.Book[1]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] = Vector(_b4.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .key1.key2[# to end].key3") {
+    val expression: String = ".Store.Book[0 to end].Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    assertEquals(Vector(
+      15.5, 12.6
+    ), future.join().getValue)
+  } //$.Store.Book[:].Price -> checked
+
+  test("Inj .key1.key2[# to end].key3") {
+    val expression: String = ".Store.Book[0 to end].Price"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Double) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(25.5, 22.6)", future.join().getValue.toString)
+  }
+
+  test("Ex .key1.key2[@elem].key3") {
+    val expression: String = ".Store.Book[@Price].Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    assertEquals(Vector(
+      "Java", "C++"
+    ), future.join().getValue)
+  } //$.Store.Book[?(@.Price)].Title -> checked
+
+  test("Inj .key1.key2[@elem].key3") {
+    val expression: String = ".Store.Book[@Price].Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Java!!!, C++!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex .key1.key2[#].key3[@elem].k*y") {
+    val expression: String = ".Store.Book[0 to end].SpecialEditions[@Price].T*le"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "JavaMachine", "ScalaMachine", "C++Machine"
+    ), future.join().getValue)
+  } //$.Store.Book[:].SpecialEditions[?(@.Price)].Title -> checked
+
+  //-----------------------------------------------------------------------------------------------------//
+
+  test("Inj .key1.key2[#].key3[@elem].k*y") {
+    val expression: String = ".Store.Book[0 to end].SpecialEditions[@Price].T*le"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(JavaMachine!!!, ScalaMachine!!!, C++Machine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key V1") {
+    val expression: String = "..Title" // || "Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    assertEquals(Vector(
+      "Java", "JavaMachine", "Scala", "ScalaMachine", "C++", "C++Machine", "Java", "JavaMachine"
+    ), future.join().getValue)
+  } //$..Title -> checked
+
+  test("Inj ..key V1") {
+    val expression: String = "..Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Java!!!, JavaMachine!!!, Scala!!!, ScalaMachine!!!, C++!!!, C++Machine!!!, Java!!!, JavaMachine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key V2") {
+    val expression: String = "..Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    assertEquals(Vector(
+      15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39
+    ), future.join().getValue)
+  } //$..Price -> checked
+
+  test("Inj ..key V2") {
+    val expression: String = "..Book.*.Price"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Double) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(25.5, 22.6)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1.key2") {
+    val expression: String = "..Book.Title" //  || "Book.Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    assertEquals(Vector(
+      "Java", "Scala", "C++"
+    ), future.join().getValue)
+  } //$..Book[:].Title -> checked
+
+  test("Inj ..key1.key2") {
+    val expression: String = "..Book.Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Java, Scala, C++)", future.join().getValue.toString)
+  } //No change is perform, because Book is a Array.
+
+  test("Ex ..key1[# to end].key2") {
+    val expression: String = "..Book[0 to end].Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    assertEquals(Vector(
+      15.5, 12.6
+    ), future.join().getValue)
+  } //$..Book[:].Price -> checked
+
+  test("Inj ..key1[# to end].key2") {
+    val expression: String = "..Book[0 to end].Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Java!!!, Scala!!!, C++!!!)", future.join().getValue.toString)
+  } //Change is perform, because Book is a Array.
+
+  test("Ex ..key[@elem].key") {
+    val expression: String = "..SpecialEditions[@Price].Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "JavaMachine", "ScalaMachine", "C++Machine", "JavaMachine"
+    ), future.join().getValue)
+  } //$..SpecialEditions[?(@.Price)].Title -> checked
+
+  test("Inj ..key[@elem].key") {
+    val expression: String = "..SpecialEditions[@Price].Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(JavaMachine!!!, ScalaMachine!!!, C++Machine!!!, JavaMachine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key[@elem]") {
+    val expression: String = "..SpecialEditions[@Price]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$..SpecialEditions[?(@.Price)] -> checked
+
+  test("Inj ..key[@elem]") {
+    val expression: String = "..SpecialEditions[@Price]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(_b10.put("Street?", "im Lost").encodeToBarray(), _b9.put("Street?", "im Lost").encodeToBarray(), _b11.put("Street?", "im Lost").encodeToBarray(), _b10.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key[#] V1") {
+    val expression: String = "..SpecialEditions[0]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$..SpecialEditions[0] -> checked
+
+  test("Inj ..key[#] V1") {
+    val expression: String = "..SpecialEditions[0]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(_b10.put("Street?", "im Lost").encodeToBarray(), _b9.put("Street?", "im Lost").encodeToBarray(), _b11.put("Street?", "im Lost").encodeToBarray(), _b10.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key[#] V2") {
+    val arr5: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 12))
+    val arr4: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 18))
+    val arr3: BsonArray = new BsonArray().add(new BsonObject().put("doorOpen", arr5))
+    val arr2: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 15))
+    val obj1: BsonObject = new BsonObject().put("fridgeTemp", 5.2f).put("fanVelocity", 20.5).put("doorOpen", arr2)
+    val obj2: BsonObject = new BsonObject().put("fridgeTemp", 5.0f).put("fanVelocity", 20.6).put("thing", arr3)
+    val obj3: BsonObject = new BsonObject().put("fridgeTemp", 3.854f).put("fanVelocity", 20.5).put("doorOpen", arr4)
+    val arr: BsonArray = new BsonArray().add(obj1).add(obj2).add(obj3)
+    val bsonEvent: BsonObject = new BsonObject().put("fridgeReadings", arr)
+
+    val expression: String = "..doorOpen[0]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(
+        new BsonObject().put("fridgeTemp", 15).encodeToBarray(),
+        new BsonObject().put("fridgeTemp", 12).encodeToBarray(),
+        new BsonObject().put("fridgeTemp", 18).encodeToBarray()
+      )
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj ..key[#] V2") {
+    val arr5: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 12))
+    val arr4: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 18))
+    val arr3: BsonArray = new BsonArray().add(new BsonObject().put("doorOpen", arr5))
+    val arr2: BsonArray = new BsonArray().add(new BsonObject().put("fridgeTemp", 15))
+    val obj1: BsonObject = new BsonObject().put("fridgeTemp", 5.2f).put("fanVelocity", 20.5).put("doorOpen", arr2)
+    val obj2: BsonObject = new BsonObject().put("fridgeTemp", 5.0f).put("fanVelocity", 20.6).put("thing", arr3)
+    val obj3: BsonObject = new BsonObject().put("fridgeTemp", 3.854f).put("fanVelocity", 20.5).put("doorOpen", arr4)
+    val arr: BsonArray = new BsonArray().add(obj1).add(obj2).add(obj3)
+    val bsonEvent: BsonObject = new BsonObject().put("fridgeReadings", arr)
+
+    val expression: String = "..doorOpen[0]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(bsonEvent.encodeToBarray())
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(new BsonObject().put("fridgeTemp", 15).put("Street?", "im Lost").encodeToBarray(), new BsonObject().put("fridgeTemp", 12).put("Street?", "im Lost").encodeToBarray(), new BsonObject().put("fridgeTemp", 18).put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..*y1[@elem1].key2[@elem2]") {
+    val expression: String = "..*k[@Price].SpecialEditions[@Price]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$..Book[?(@.Price)].SpecialEditions[?(@.Price)] && $..Hatk[?(@.Price)].SpecialEditions[?(@.Price)] -> checked
+
+  test("Inj ..*y1[@elem1].key2[@elem2]") {
+    val expression: String = "..*k[@Price].SpecialEditions[@Price]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(_b10.put("Street?", "im Lost").encodeToBarray(), _b11.put("Street?", "im Lost").encodeToBarray(), _b10.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..*y1[@elem1].key2") {
+    val expression: String = "..*k[@SpecialEditions].Pr*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      15.5, 21.5, 12.6, 15.5
+    ), future.join().getValue)
+  } //$..Book[?(@.SpecialEditions)].Price && $..Hatk[?(@.SpecialEditions)].Price -> checked
+
+  //---------------------------------------------------------------------------------------------------//
+
+  test("Inj ..*y1[@elem1].key2") {
+    val expression: String = "..*k[@SpecialEditions].Pr*"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Double) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(25.5, 31.5, 22.6, 25.5)", future.join().getValue.toString)
+  }
+
+  test("Ex .key1..key2") {
+    val expression: String = ".Store..Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39
+    ), future.join().getValue)
+  } //$.Store..Price -> checked
+
+  test("Inj .key1..key2") {
+    //No Change is perform, because not all values are of the same type
+    val expression: String = ".Store..Price"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Double) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39)", future.join().getValue.toString)
+  } //No Change is perform, because not all values are of the same type
+
+  test("Ex .key1..key2[@elem]") {
+    val expression: String = ".Store..SpecialEditions[@Price]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.Store..SpecialEditions[?(@.Price)] -> checked
+
+  test("Inj .key1..key2[@elem]") {
+    //No Change is perform, because not all values are of the same type
+    val expression: String = ".Store..SpecialEditions[@Price]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(_b10.put("Street?", "im Lost").encodeToBarray(), _b9.put("Street?", "im Lost").encodeToBarray(), _b11.put("Street?", "im Lost").encodeToBarray(), _b10.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .key1..key2[#]") {
+    val expression: String = ".Store..SpecialEditions[0]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.Store..SpecialEditions[0] -> checked
+
+  test("Inj .key1..key2[#]") {
+    //No Change is perform, because not all values are of the same type
+    val expression: String = ".Store..SpecialEditions[0]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(_b10.put("Street?", "im Lost").encodeToBarray(), _b9.put("Street?", "im Lost").encodeToBarray(), _b11.put("Street?", "im Lost").encodeToBarray(), _b10.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .key1..key2[#]..key3") {
+    val expression: String = ".Store..Book[0 until end]..Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "Java",
+      "JavaMachine",
+      "Scala",
+      "ScalaMachine"
+    ), future.join().getValue)
+  } //$.Store..Book[0:2]..Title -> checked
+
+  test("Inj .key1..key2[#]..key3") {
+    val expression: String = ".Store..Book[0 until end]..Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Java!!!, JavaMachine!!!, Scala!!!, ScalaMachine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex .key1..key2[#]..key3[@elem]") {
+    val expression: String = ".Store..Book[1 until end]..SpecialEditions[@Price]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b9.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.Store..Book[1:2]..SpecialEditions[?(@.Price)] -> checked
+
+  test("Inj .key1..key2[#]..key3[@elem]") {
+    val expression: String = ".Store..Book[1 until end]..SpecialEditions[@Price]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+    //println("injFuture=" + new String(injFuture.join()))
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(_b9.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .*y1..*y2[#]..*y3..key4") {
+    val expression: String = ".*ore..*k[1 until end]..*Editions..Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector("ScalaMachine"), future.join().getValue)
+  } //$.Store..Book[1:2]..SpecialEditions..Title -> checked
+
+  test("Inj .*y1..*y2[#]..*y3..key4") {
+    val expression: String = ".*ore..*k[1 until end]..*Editions..Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+    //println("injFuture=" + new String(injFuture.join()))
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(ScalaMachine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex .key1..key2[@elem1]..key3[@elem2]") {
+    val expression: String = ".Store..*k[@Price]..SpecialEditions[@Title]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.Store..Book[?(@.Price)]..SpecialEditions[?(@.Title)] && $.Store..Hatk[?(@.Price)]..SpecialEditions[?(@.Title)] -> checked
+
+  //---------------------------------------------------------------------------------------------------//
+
+  test("Inj .key1..key2[@elem1]..key3[@elem2]") {
+    val expression: String = ".Store..*k[@Price]..SpecialEditions[@Title]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street?", "im Lost"))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(_b10.put("Street?", "im Lost").encodeToBarray(), _b11.put("Street?", "im Lost").encodeToBarray(), _b10.put("Street?", "im Lost").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key1[#]..key2") {
+    val expression: String = "..Book[0 to end]..Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      15.5, 39, 40, 12.6, 38
+    ), future.join().getValue)
+  } //$..Book[:]..Price -> checked
+
+  test("Inj ..key1[#]..key2") {
+    val expression: String = "..Book[0 to end]..Price"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+    //println("injFuture=" + new String(injFuture.join()))
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(15.5, 39, 40, 12.6, 38)", future.join().getValue.toString)
+  } //No Change is perform, because not all values are of the same type
+
+  test("Ex ..key1..key2") {
+    val expression: String = "Store..Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39
+    ), future.join().getValue)
+  } //$..Store..Price -> checked
+
+  test("Inj ..key1..key2") {
+    val expression: String = "Store..Price"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+    // println("injFuture=" + new String(injFuture.join()))
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(15.5, 39, 40, 12.6, 38, 48, 35, 38, 15.5, 39)", future.join().getValue.toString)
+  } //No Change is perform, because not all values are of the same type
+
+  test("Ex ..key1[@elem]..key2") {
+    val expression: String = "Book[@Price]..Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "Java", "JavaMachine", "C++", "C++Machine"
+    ), future.join().getValue)
+  } //$..Book[?(@.Price)]..Title -> checked
+
+  test("Inj ..key1[@elem]..key2") {
+    val expression: String = "Book[@Price]..Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Java!!!, JavaMachine!!!, C++!!!, C++Machine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1..*ey2..*ey3") {
+    val expression: String = "Store..*k..*itions"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    val expected: Vector[Array[Byte]] = Vector(br4.encodeToBarray(), br3.encodeToBarray(), br5.encodeToBarray(), br4.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$..Store..Book..SpecialEditions && $..Store..Hatk..SpecialEditions -> checked
+
+  test("Inj ..key1..*ey2..*ey3") {
+    val expression: String = "Store..*k..*itions"
+
+    //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("NewEdition!"))
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val l: List[Any] = Mapper.decodeBsonArray(b.getByteBuf)
+      val newL: List[Any] = l.:+("NewEdition!")
+      val res: ByteBuf = Mapper.encode(newL)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+    // println("injFuture=" + new String(injFuture.join()))
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+    val xbr4 = new BsonArray().add(new BsonObject().put("Price", 39).put("Title", "JavaMachine")).add("NewEdition!").encodeToBarray()
+    val xbr3 = new BsonArray().add(new BsonObject().put("Price", 40).put("Title", "ScalaMachine")).add("NewEdition!").encodeToBarray()
+    val xbr5 = new BsonArray().add(new BsonObject().put("Price", 38).put("Title", "C++Machine")).add("NewEdition!").encodeToBarray()
+
+    val expected: Vector[Array[Byte]] = Vector(xbr4, xbr3, xbr5, xbr4)
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key1.key2..key3") {
+    val expression: String = "..Book.SpecialEditions..Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      39, 40, 38
+    ), future.join().getValue)
+  } //$..Book[:].SpecialEditions..Price -> checked
+
+  //---------------------------------------------------------------------------------------------------//
+
+  test("Inj ..key1.key2..key3") {
+    val expression: String = "..Book.SpecialEditions..Price"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(39, 40, 38)", future.join().getValue.toString)
+  } // Change is not perform because Book is an array, and the expression misses the Array specification
+
+  test("Ex .key.*") {
+    val expression: String = ".Store.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(br1.encodeToBarray(), br2.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj .key.*") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+
+    val expression: String = ".Store.*"
+
+    //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.:+("newField!"))
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val l: List[Any] = Mapper.decodeBsonArray(b.getByteBuf)
+      val newL: List[Any] = l.:+("newField!")
+      val res: ByteBuf = Mapper.encode(newL)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] = Vector(xbr1.add("newField!").encodeToBarray(), xbr2.add("newField!").encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key.*") {
+    val expression: String = "SpecialEditions.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj ..key.*") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+
+    val expression: String = "SpecialEditions.*"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("newField!", 100))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(xb10.put("newField!", 100).encodeToBarray(), xb9.put("newField!", 100).encodeToBarray(), xb11.put("newField!", 100).encodeToBarray(), xb10.put("newField!", 100).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key[#].*") {
+    val expression: String = "SpecialEditions[0 to end].*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "JavaMachine",
+      39,
+      "ScalaMachine",
+      40,
+      "C++Machine",
+      38,
+      "JavaMachine",
+      39
+    ), future.join().getValue)
+  }
+
+  test("Inj ..key[#].*") {
+    val expression: String = "SpecialEditions[0 to end].*"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(JavaMachine, 39, ScalaMachine, 40, C++Machine, 38, JavaMachine, 39)", future.join().getValue.toString)
+  } // Change is not perform because the values are not the same type
+
+  test("Ex ..key1.*.key2") {
+    val expression: String = "Book.*.Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "Java",
+      "Scala",
+      "C++"
+    ), future.join().getValue)
+  }
+
+  test("Inj ..key1.*.key2") {
+    val expression: String = "Book.*.Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Java!!!, Scala!!!, C++!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1.*..key2") {
+    val expression: String = "Book.*..Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "Java",
+      "JavaMachine",
+      "Scala",
+      "ScalaMachine",
+      "C++",
+      "C++Machine"
+    ), future.join().getValue)
+  }
+
+  test("Inj ..key1.*..key2") {
+    val expression: String = "Book.*..Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Java!!!, JavaMachine!!!, Scala!!!, ScalaMachine!!!, C++!!!, C++Machine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1[#].*.key2") {
+    val expression: String = "Book[0 to end].*.Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(), future.join().getValue)
+  }
+
+  test("Inj ..key1[#].*.key2") {
+    val expression: String = "Book[0 to end].*.Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector()", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1[#].*..key2") {
+    val expression: String = "Book[0 to end].*..Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "JavaMachine",
+      "ScalaMachine",
+      "C++Machine"
+    ), future.join().getValue)
+  }
+
+  test("Inj ..key1[#].*..key2") {
+    val expression: String = "Book[0 to end].*..Title"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(JavaMachine!!!, ScalaMachine!!!, C++Machine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1.*.key2[@elem]") {
+    val expression: String = "Book.*.SpecialEditions[@Price]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj ..key1.*.key2[@elem]") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+    val expression: String = "Book.*.SpecialEditions[@Price]"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(xb10.put("Street", 1000).encodeToBarray(), xb9.put("Street", 1000).encodeToBarray(), xb11.put("Street", 1000).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key[@elem].*") {
+    val expression: String = "SpecialEditions[@Price].*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "JavaMachine",
+      39,
+      "ScalaMachine",
+      40,
+      "C++Machine",
+      38,
+      "JavaMachine",
+      39
+    ), future.join().getValue)
+  }
+
+  test("Inj ..key[@elem].*") {
+    val expression: String = "SpecialEditions[@Price].*"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(JavaMachine, 39, ScalaMachine, 40, C++Machine, 38, JavaMachine, 39)", future.join().getValue.toString)
+  } // Change is not perform because the values are not the same type
+
+  test("Ex ..key1[#].*.key2[@elem]") {
+    val expression: String = "Book[0 to end].*..SpecialEditions[@Price]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(), future.join().getValue)
+  }
+
+  test("Inj ..key1[#].*.key2[@elem]") {
+    val expression: String = "Book[0 to end].*..SpecialEditions[@Price]"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector()", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1.*.[#]") {
+    val expression: String = "Book.*.[0 to end]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(), future.join().getValue)
+  }
+
+  test("Inj ..key1.*.[#]") {
+    val expression: String = "Book.*.[0 to end]"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector()", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1[#].*.[#]") {
+    val expression: String = "Book[0 to end].*.[0 to end]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj ..key1[#].*.[#]") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+    val expression: String = "Book[0 to end].*.[0 to end]"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(xb10.put("Street", 1000).encodeToBarray(), xb9.put("Street", 1000).encodeToBarray(), xb11.put("Street", 1000).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key1[#].*..[#]") {
+    val expression: String = "Book[0 to end].*..[0 to end]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj ..key1[#].*..[#]") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+    val expression: String = "Book[0 to end].*..[0 to end]"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(xb10.put("Street", 1000).encodeToBarray(), xb9.put("Street", 1000).encodeToBarray(), xb11.put("Street", 1000).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key1[#].*..[#]..k*y2") {
+    val expression: String = "Book[0 to end].*..[0 to end]..Ti*e"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      "JavaMachine",
+      "ScalaMachine",
+      "C++Machine"
+    ), future.join().getValue)
+  }
+
+  test("Inj ..key1[#].*..[#]..k*y2") {
+    val expression: String = "Book[0 to end].*..[0 to end]..Ti*e"
+
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(JavaMachine!!!, ScalaMachine!!!, C++Machine!!!)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1[#].*.[#].key2") {
+    val expression: String = "Book[0 to end].*..[0 to end].Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    assertEquals(Vector(
+      39, 40, 38
+    ), future.join().getValue)
+  }
+
+  test("Inj ..key1[#].*.[#].key2") {
+    val expression: String = "Book[0 to end].*..[0 to end].Price"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(49, 50, 48)", future.join().getValue.toString)
+  }
+
+  test("Ex ..key1[#].*.*") {
+    val expression: String = "Book[0 to end].*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj ..key1[#].*.*") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+    val expression: String = "Book[0 to end].*.*"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(xb10.put("Street", 1000).encodeToBarray(), xb9.put("Street", 1000).encodeToBarray(), xb11.put("Street", 1000).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex ..key1.*.*") {
+    val expression: String = "Book.*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Any] = Vector("Java", 15.5, br4.encodeToBarray(), "Scala", 21.5, br3.encodeToBarray(), "C++", 12.6, br5.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Inj ..key1.*.*") {
+    val expression: String = "Book.*.*"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Int) => x + 10)
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Any] = Vector("Java", 15.5, br4.encodeToBarray(), "Scala", 21.5, br3.encodeToBarray(), "C++", 12.6, br5.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  } // Change is not perform because the values are not the same type
+
+  test("Ex .key1.*.*") {
+    val expression: String = "Store.*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b3.encodeToBarray(), b4.encodeToBarray(), b8.encodeToBarray(), b5.encodeToBarray(), b6.encodeToBarray(), b7.encodeToBarray(), b3.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj .key1.*.*") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+    val expression: String = "Store.*.*"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(xb3.put("Street", 1000).encodeToBarray(), xb4.put("Street", 1000).encodeToBarray(), xb8.put("Street", 1000).encodeToBarray(), xb5.put("Street", 1000).encodeToBarray(), xb6.put("Street", 1000).encodeToBarray(), xb7.put("Street", 1000).encodeToBarray(), xb3.put("Street", 1000).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .key1.*.*.*.*") {
+    val expression: String = "Store.*.*.*.*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+    val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj .key1.*.*.*.*") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+    val expression: String = "Store.*.*.*.*"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(xb10.put("Street", 1000).encodeToBarray(), xb9.put("Street", 1000).encodeToBarray(), xb11.put("Street", 1000).encodeToBarray(), xb10.put("Street", 1000).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex .*") {
+    val expression: String = ".*"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(validatedByteArr)
+
+    val expected: Vector[Array[Byte]] = Vector(b2.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  } //$.* -> checked
+
+  test("Inj .*") {
+    val xb11: BsonObject = new BsonObject().put("Price", 38).put("Title", "C++Machine")
+    val xbr5: BsonArray = new BsonArray().add(xb11)
+    val xb10: BsonObject = new BsonObject().put("Price", 39).put("Title", "JavaMachine")
+    val xbr4: BsonArray = new BsonArray().add(xb10)
+    val xb9: BsonObject = new BsonObject().put("Price", 40).put("Title", "ScalaMachine")
+    val xbr3: BsonArray = new BsonArray().add(xb9)
+    val xb7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val xb6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val xb5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val xb4: BsonObject = new BsonObject().put("Pri", 21.5).put("SpecialEditions", xbr3).put("Title", "Scala")
+    val xb3: BsonObject = new BsonObject().put("Price", 15.5).put("SpecialEditions", xbr4).put("Title", "Java")
+    val xb8: BsonObject = new BsonObject().put("Price", 12.6).put("SpecialEditions", xbr5).put("Title", "C++")
+    val xbr1: BsonArray = new BsonArray().add(xb3).add(xb4).add(xb8)
+    val xbr2: BsonArray = new BsonArray().add(xb5).add(xb6).add(xb7).add(xb3)
+    val xb2: BsonObject = new BsonObject().put("Book", xbr1).put("Hatk", xbr2)
+    val xbsonEvent: BsonObject = new BsonObject().put("Store", xb2)
+    val expression: String = ".*"
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val expected: Vector[Array[Byte]] =
+      Vector(xb2.put("Street", 1000).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  //    test("Ex ..*"){
+  //      val expression: String = "..*"
+  //      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+  //      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+  //      boson.go(validatedByteArr)
+  //
+  //      assertEquals(Vector(
+  //        Map("Book" -> Seq(Map("Title" -> "Java", "Price" -> 15.5, "SpecialEditions" -> Seq(Map("Title" -> "JavaMachine", "Price" -> 39))),
+  //          Map("Title" -> "Scala", "Pri" -> 21.5, "SpecialEditions" -> Seq(Map("Title" -> "ScalaMachine", "Price" -> 40))),
+  //          Map("Title" -> "C++", "Price" -> 12.6, "SpecialEditions" -> Seq(Map("Title" -> "C++Machine", "Price" -> 38)))),
+  //          "Hatk" -> Seq(Map("Color" -> "Red", "Price" -> 48), Map("Color" -> "White", "Price" -> 35), Map("Color" -> "Blue", "Price" -> 38),
+  //            Map("Title" -> "Java", "Price" -> 15.5, "SpecialEditions" -> Seq(Map("Title" -> "JavaMachine", "Price" -> 39)))))
+  //      ), future.join().getValue)
+  //    } //TODO: Not implemented yet, so this test is wrong
+
+  //    test("Inj ..* V1"){
+  //      val expression: String = "..*"
+  //
+  //      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+  //        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+  //        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
+  //        val newM: Map[String, Any] = m.+(("Street", 1000))
+  //        val res: ByteBuf = Mapper.encode(newM)
+  //        if(res.hasArray)
+  //          res.array()
+  //        else {
+  //          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+  //          val array: Array[Byte] = buf.array()
+  //          buf.release()
+  //          array
+  //        }
+  //      })
+  //      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+  //      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+  //      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+  //      boson.go(injFuture.join())
+  //
+  //      assertEquals("Vector(Map(Book -> List(Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))), Map(Title -> Scala, Pri -> 21.5, SpecialEditions -> List(Map(Title -> ScalaMachine, Price -> 40))), Map(Title -> C++, Price -> 12.6, SpecialEditions -> List(Map(Title -> C++Machine, Price -> 38)))), Hatk -> List(Map(Color -> Red, Price -> 48), Map(Color -> White, Price -> 35), Map(Color -> Blue, Price -> 38), Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))))))", future.join().getValue.toString)
+  //    } // No change is perform because the values are not the same type //TODO: Not implemented yet(extractor), so this test is wrong
+
+  /*test("Inj ..* V1"){
+    val expression: String = "..*"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if(res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(validatedByteArr)
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    assertEquals("Vector(Map(Book -> List(Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))), Map(Title -> Scala, Pri -> 21.5, SpecialEditions -> List(Map(Title -> ScalaMachine, Price -> 40))), Map(Title -> C++, Price -> 12.6, SpecialEditions -> List(Map(Title -> C++Machine, Price -> 38)))), Hatk -> List(Map(Color -> Red, Price -> 48), Map(Color -> White, Price -> 35), Map(Color -> Blue, Price -> 38), Map(Title -> Java, Price -> 15.5, SpecialEditions -> List(Map(Title -> JavaMachine, Price -> 39))))))", future.join().getValue.toString)
+  } // No change is perform because the values are not the same type*/
   ////TODO: Not implemented yet(extractor), so this test is wrong
 
-    test("Inj ..* V2"){
-      val expression: String = "..*"
-      val rootx: BsonObject = new BsonObject().put("field1", "OneWord!!").put("field2", "TwoWords!!").put("field3", "ThreeWords!!").put("field4", "FourWords!!")
-      val root: BsonObject = new BsonObject().put("field1", "OneWord").put("field2", "TwoWords").put("field3", "ThreeWords").put("field4", "FourWords")
-      val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!") )
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(root.encodeToBarray())
-      assertTrue(rootx.encodeToBarray().zip(injFuture.join()).forall(p => p._1 == p._2))
-  }
-
-    test("Inj ..* V3"){
+  test("Inj ..* V2") {
     val expression: String = "..*"
-      val field2x: BsonObject = new BsonObject().put("field4", new BsonObject().put("newField", 10)).put("newField", 10)
-      val field1x: BsonObject = new BsonObject().put("field3", new BsonObject().put("newField", 10)).put("newField", 10)
-      val rootx: BsonObject = new BsonObject().put("field1",field1x ).put("field2", field2x )
-
-
-      val field2: BsonObject = new BsonObject().put("field4", new BsonObject())
-      val field1: BsonObject = new BsonObject().put("field3", new BsonObject())
-      val root: BsonObject = new BsonObject().put("field1",field1 ).put("field2", field2 )
-
-      //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("ADDED"))
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val l: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newL: Map[String, Any] = l.+(("newField", 10))
-        val res: ByteBuf = Mapper.encode(newL)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(root.encodeToBarray())
-
-      rootx.encodeToBarray().zip(injFuture.join()).forall(p => p._1 == p._2)
-
-      assertTrue(rootx.encodeToBarray().zip(injFuture.join()).forall(p => p._1 == p._2))
+    val rootx: BsonObject = new BsonObject().put("field1", "OneWord!!").put("field2", "TwoWords!!").put("field3", "ThreeWords!!").put("field4", "FourWords!!")
+    val root: BsonObject = new BsonObject().put("field1", "OneWord").put("field2", "TwoWords").put("field3", "ThreeWords").put("field4", "FourWords")
+    val bosonI: Boson = Boson.injector(expression, (x: String) => x.concat("!!"))
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(root.encodeToBarray())
+    assertTrue(rootx.encodeToBarray().zip(injFuture.join()).forall(p => p._1 == p._2))
   }
 
-    test("Ex ..key, but multiple keys with same name"){
-      val obj2: BsonObject = new BsonObject().put("Store", 1000L)
-      val obj1: BsonObject = new BsonObject().put("Store", obj2)
-      val expression: String = "..Store"
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(obj1.encodeToBarray())
+  test("Inj ..* V3") {
+    val expression: String = "..*"
+    val field2x: BsonObject = new BsonObject().put("field4", new BsonObject().put("newField", 10)).put("newField", 10)
+    val field1x: BsonObject = new BsonObject().put("field3", new BsonObject().put("newField", 10)).put("newField", 10)
+    val rootx: BsonObject = new BsonObject().put("field1", field1x).put("field2", field2x)
 
-      val expected: Vector[Any] = Vector(obj2.encodeToBarray(),1000L)
-      val res = future.join().getValue.asInstanceOf[Vector[Any]]
-      assert(expected.size === res.size)
-      assertTrue(expected.zip(res).forall{
-        case (e: Array[Byte],r: Array[Byte]) => e.sameElements(r)
-        case (e,r) => e.equals(r)
-      })
-    }
 
-    test("Inj ..key, but multiple keys with same name V1"){
-      val obj2: BsonObject = new BsonObject().put("Store", 1000L)
-      val obj1: BsonObject = new BsonObject().put("Store", obj2)
-      val expression: String = "..Store"
+    val field2: BsonObject = new BsonObject().put("field4", new BsonObject())
+    val field1: BsonObject = new BsonObject().put("field3", new BsonObject())
+    val root: BsonObject = new BsonObject().put("field1", field1).put("field2", field2)
 
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj1.encodeToBarray())
+    //val bosonI: Boson = Boson.injector(expression, (x: List[Any]) => x.+:("ADDED"))
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val l: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newL: Map[String, Any] = l.+(("newField", 10))
+      val res: ByteBuf = Mapper.encode(newL)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(root.encodeToBarray())
 
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
+    rootx.encodeToBarray().zip(injFuture.join()).forall(p => p._1 == p._2)
 
-      val expected: Vector[Any] = Vector(obj2.encodeToBarray(), 1000L)
-      val result = future.join().getValue.asInstanceOf[Vector[Any]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall{
-        case (e: Array[Byte],r: Array[Byte]) => e.sameElements(r)
-        case (e,r) => e.equals(r)
-      })
-    }
+    assertTrue(rootx.encodeToBarray().zip(injFuture.join()).forall(p => p._1 == p._2))
+  }
 
-    test("Inj ..key, but multiple keys with same name V2"){
-      val obj22: BsonObject = new BsonObject().put("Store", new BsonObject())
-      val obj11: BsonObject = new BsonObject().put("Store", obj22)
-      println(obj11)
-      val expression: String = "..Store"
+  test("Ex ..key, but multiple keys with same name") {
+    val obj2: BsonObject = new BsonObject().put("Store", 1000L)
+    val obj1: BsonObject = new BsonObject().put("Store", obj2)
+    val expression: String = "..Store"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(obj1.encodeToBarray())
 
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj11.encodeToBarray())
+    val expected: Vector[Any] = Vector(obj2.encodeToBarray(), 1000L)
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
 
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
+  test("Inj ..key, but multiple keys with same name V1") {
+    val obj2: BsonObject = new BsonObject().put("Store", 1000L)
+    val obj1: BsonObject = new BsonObject().put("Store", obj2)
+    val expression: String = "..Store"
 
-      val xobj22: BsonObject = new BsonObject().put("Store", new BsonObject().put("Street", 1000))
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj1.encodeToBarray())
 
-      val expected: Vector[Array[Byte]] =
-        Vector(xobj22.put("Street", 1000).encodeToBarray(), new BsonObject().put("Street", 1000).encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
 
-    test("Inj ..key1[@Key2]") {
-      val obj555: BsonObject = new BsonObject().put("Store", new BsonArray())
-      val arr444: BsonArray = new BsonArray().add(obj555).add(obj555)
-      val obj333: BsonObject = new BsonObject().put("Store", arr444)
-      val arr222: BsonArray = new BsonArray().add(obj333).add(obj333)
-      //put("Store",new BsonObject())
-      val obj111: BsonObject = new BsonObject().put("Store", arr222)
-      val expression: String = "..Store[@Store]"
+    val expected: Vector[Any] = Vector(obj2.encodeToBarray(), 1000L)
+    val result = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
 
-      val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
-        val b: BosonImpl = new BosonImpl(byteArray = Option(x))
-        val m: Map[String,Any] = Mapper.decodeBsonObject(b.getByteBuf)
+  test("Inj ..key, but multiple keys with same name V2") {
+    val obj22: BsonObject = new BsonObject().put("Store", new BsonObject())
+    val obj11: BsonObject = new BsonObject().put("Store", obj22)
+    println(obj11)
+    val expression: String = "..Store"
 
-        val newM: Map[String, Any] = m.+(("Street", 1000))
-        val res: ByteBuf = Mapper.encode(newM)
-        if(res.hasArray)
-          res.array()
-        else {
-          val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
-          val array: Array[Byte] = buf.array()
-          buf.release()
-          array
-        }
-      })
-      val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj111.encodeToBarray())
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj11.encodeToBarray())
 
-      val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
-      val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
-      boson.go(injFuture.join())
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
 
-      val xobj555: BsonObject = new BsonObject().put("Store", new BsonArray()).put("Street", 1000)
-      val xobj333: BsonObject = new BsonObject().put("Store", new BsonArray().add(xobj555).add(xobj555)).put("Street", 1000)
+    val xobj22: BsonObject = new BsonObject().put("Store", new BsonObject().put("Street", 1000))
 
-      val expected: Vector[Array[Byte]] = Vector(xobj333.encodeToBarray(), xobj555.encodeToBarray(), xobj555.encodeToBarray(), xobj333.encodeToBarray(), xobj555.encodeToBarray(), xobj555.encodeToBarray())
-      val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
-      assert(expected.size === result.size)
-      assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
-    }
+    val expected: Vector[Array[Byte]] =
+      Vector(xobj22.put("Street", 1000).encodeToBarray(), new BsonObject().put("Street", 1000).encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Inj ..key1[@Key2]") {
+    val obj555: BsonObject = new BsonObject().put("Store", new BsonArray())
+    val arr444: BsonArray = new BsonArray().add(obj555).add(obj555)
+    val obj333: BsonObject = new BsonObject().put("Store", arr444)
+    val arr222: BsonArray = new BsonArray().add(obj333).add(obj333)
+    //put("Store",new BsonObject())
+    val obj111: BsonObject = new BsonObject().put("Store", arr222)
+    val expression: String = "..Store[@Store]"
+
+    val bosonI: Boson = Boson.injector(expression, (x: Array[Byte]) => {
+      val b: BosonImpl = new BosonImpl(byteArray = Option(x))
+      val m: Map[String, Any] = Mapper.decodeBsonObject(b.getByteBuf)
+
+      val newM: Map[String, Any] = m.+(("Street", 1000))
+      val res: ByteBuf = Mapper.encode(newM)
+      if (res.hasArray)
+        res.array()
+      else {
+        val buf: ByteBuf = Unpooled.buffer(res.capacity()).writeBytes(res)
+        val array: Array[Byte] = buf.array()
+        buf.release()
+        array
+      }
+    })
+    val injFuture: CompletableFuture[Array[Byte]] = bosonI.go(obj111.encodeToBarray())
+
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(injFuture.join())
+
+    val xobj555: BsonObject = new BsonObject().put("Store", new BsonArray()).put("Street", 1000)
+    val xobj333: BsonObject = new BsonObject().put("Store", new BsonArray().add(xobj555).add(xobj555)).put("Street", 1000)
+
+    val expected: Vector[Array[Byte]] = Vector(xobj333.encodeToBarray(), xobj555.encodeToBarray(), xobj555.encodeToBarray(), xobj333.encodeToBarray(), xobj555.encodeToBarray(), xobj555.encodeToBarray())
+    val result = future.join().getValue.asInstanceOf[Vector[Array[Byte]]]
+    assert(expected.size === result.size)
+    assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
+  }
+
+  test("Ex '.' BsonObject Root") {
+    val expression: String = "."
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(bsonEvent.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex '.' BsonArray Root") {
+    val expression: String = "."
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(br1.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(br1.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex .[first]") {
+    val expression: String = "to"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(br1.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(br1.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
 
 }

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -2179,12 +2179,28 @@ class jpPlusPlusTests extends FunSuite {
   }
 
   test("Ex [end]..[end]") {
+    val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
+    val br5: BsonArray = new BsonArray().add(b11)
+    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
+    val br4: BsonArray = new BsonArray().add(b10)
+    val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
+    val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val b4: BsonObject = new BsonObject().put("Title", "Scala").put("Pri", 21.5).put("SpecialEditions", br3)
+    val b3: BsonObject = new BsonObject().put("Title", "Java").put("Price", 15.5).put("SpecialEditions", br4)
+    val b8: BsonObject = new BsonObject().put("Title", "C++").put("Price", 12.6).put("SpecialEditions", br5)
+    val br1: BsonArray = new BsonArray().add(b3).add(b4).add(b8)
+    val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
+    val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
+    val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
     val expression: String = "[end]..[end]"
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
     boson.go(bsonEvent.encodeToBarray())
 
-    val expected: Vector[Any] = Vector(b11.encodeToBarray(), b10.encodeToBarray())
+    val expected: Vector[Any] = Vector(b11.encodeToBarray(), b11.encodeToBarray(), b11.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray(), b11.encodeToBarray(), b11.encodeToBarray())
     val res = future.join().getValue.asInstanceOf[Vector[Any]]
     assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall {
@@ -2215,6 +2231,114 @@ class jpPlusPlusTests extends FunSuite {
     })
   }
 
+  test("Ex [end]..[end].Key") {
+    val expression: String = "[end]..[end].Price"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(38,39)
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex [#to end]..[end]..*[@elem]") {
+    val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
+    val br5: BsonArray = new BsonArray().add(b11)
+    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
+    val br4: BsonArray = new BsonArray().add(b10)
+    val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
+    val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val b4: BsonObject = new BsonObject().put("Title", "Scala").put("Pri", 21.5).put("SpecialEditions", br3)
+    val b3: BsonObject = new BsonObject().put("Title", "Java").put("Price", 15.5).put("SpecialEditions", br4)
+    val b8: BsonObject = new BsonObject().put("Title", "C++").put("Price", 12.6).put("SpecialEditions", br5)
+    val br1: BsonArray = new BsonArray().add(b3).add(b4).add(b8)
+    val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
+    val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
+    val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
+    val expression: String = "[1 to end]..[end]..Special*[@Title]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(b11.encodeToBarray(),b11.encodeToBarray(),b11.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex [#to#]..[end]..*[@elem]") {
+    val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
+    val br5: BsonArray = new BsonArray().add(b11)
+    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
+    val br4: BsonArray = new BsonArray().add(b10)
+    val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
+    val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val b4: BsonObject = new BsonObject().put("Title", "Scala").put("Pri", 21.5).put("SpecialEditions", br3)
+    val b3: BsonObject = new BsonObject().put("Title", "Java").put("Price", 15.5).put("SpecialEditions", br4)
+    val b8: BsonObject = new BsonObject().put("Title", "C++").put("Price", 12.6).put("SpecialEditions", br5)
+    val br1: BsonArray = new BsonArray().add(b3).add(b4).add(b8)
+    val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
+    val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
+    val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
+    val expression: String = "[1]..[end]..Specia*ditions[@Title]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(b11.encodeToBarray(),b11.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex [end]..[end]..*[@elem]") {
+    val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
+    val br5: BsonArray = new BsonArray().add(b11)
+    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
+    val br4: BsonArray = new BsonArray().add(b10)
+    val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
+    val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val b4: BsonObject = new BsonObject().put("Title", "Scala").put("Pri", 21.5).put("SpecialEditions", br3)
+    val b3: BsonObject = new BsonObject().put("Title", "Java").put("Price", 15.5).put("SpecialEditions", br4)
+    val b8: BsonObject = new BsonObject().put("Title", "C++").put("Price", 12.6).put("SpecialEditions", br5)
+    val br1: BsonArray = new BsonArray().add(b3).add(b4).add(b8)
+    val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
+    val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
+    val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
+    val expression: String = "[end]..[end]..SpecialEditions[@Title]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(b11.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
   test("Ex [# to end]..Key1") {
     val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
     val br5: BsonArray = new BsonArray().add(b11)
@@ -2233,7 +2357,6 @@ class jpPlusPlusTests extends FunSuite {
     val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
     val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
     val expression: String = "[1 to end]..SpecialEditions[@Price]"
-    println(bsonEvent)
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
     boson.go(bsonEvent.encodeToBarray())
@@ -2250,11 +2373,9 @@ class jpPlusPlusTests extends FunSuite {
       b10.encodeToBarray()
     )
     val res = future.join().getValue.asInstanceOf[Vector[Any]]
-    println(s"res: $res")
     assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall {
       case (e: Array[Byte], r: Array[Byte]) =>
-        println(s"e: $e, r: $r, are they equal? ${e.sameElements(r)}")
         e.sameElements(r)
       case (e, r) => e.equals(r)
     })

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -2098,12 +2098,57 @@ class jpPlusPlusTests extends FunSuite {
   }
 
   test("Ex .[first]") {
-    val expression: String = "to"
+    val expression: String = ".[first]"
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
     boson.go(br1.encodeToBarray())
 
-    val expected: Vector[Any] = Vector(br1.encodeToBarray())
+    val expected: Vector[Any] = Vector(b3.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex key1.key2[all]") {
+    val expression: String = "Store.Book[all]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(b3.encodeToBarray(),b4.encodeToBarray(),b8.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex key[end]") {
+    val expression: String = "Book[end]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(b8.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex key1[end]..key2") {
+    val expression: String = "Book[end]..Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector("C++","C++Machine")
     val res = future.join().getValue.asInstanceOf[Vector[Any]]
     assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall {

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -458,6 +458,7 @@ class jpPlusPlusTests extends FunSuite {
   }
 
   test("Ex ..key[#] V1") {
+    println(bsonEvent)
     val expression: String = "..SpecialEditions[0]"
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
@@ -465,6 +466,7 @@ class jpPlusPlusTests extends FunSuite {
 
     val expected: Vector[Array[Byte]] = Vector(b10.encodeToBarray(), b9.encodeToBarray(), b11.encodeToBarray(), b10.encodeToBarray())
     val result = future.join().getValue.asInstanceOf[Vector[Array[Any]]]
+    println(s"result: $result")
     assert(expected.size === result.size)
     assertTrue(expected.zip(result).forall(b => b._1.sameElements(b._2)))
   } //$..SpecialEditions[0] -> checked
@@ -2501,6 +2503,38 @@ class jpPlusPlusTests extends FunSuite {
 
     val expected: Vector[Any] = Vector(new BsonObject().put("some", new BsonObject()).put("field", new BsonArray().add(2)).encodeToBarray())
     val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex...") {
+    val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
+    val br5: BsonArray = new BsonArray().add(b11)
+    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
+    val br4: BsonArray = new BsonArray().add(b10)
+    val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
+    val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val b4: BsonObject = new BsonObject().put("Title", "Scala").put("Pri", 21.5).put("SpecialEditions", br3)
+    val b3: BsonObject = new BsonObject().put("Title", "Java").put("Price", 15.5).put("SpecialEditions", br4)
+    val b8: BsonObject = new BsonObject().put("Title", "C++").put("Price", 12.6).put("SpecialEditions", br5)
+    val br1: BsonArray = new BsonArray().add(b3).add(b4).add(b8)
+    val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
+    val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
+    val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
+    val expression: String = "SpecialEditions[0]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(b10.encodeToBarray(), b11.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    println(s"res: $res")
     assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall {
       case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)

--- a/src/test/scala/io/boson/jpPlusPlusTests.scala
+++ b/src/test/scala/io/boson/jpPlusPlusTests.scala
@@ -2398,7 +2398,7 @@ class jpPlusPlusTests extends FunSuite {
     })
   }
 
-  test("Ex key1[end]..key2 END has Arr") {
+  test("Ex [end]..key2 END has Arr") {
     val arr: BsonArray = new BsonArray().add(b3).add(b4).add(new BsonArray().add(new BsonObject().put("field", "value")))
     val expression: String = "[end]..field"
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
@@ -2510,7 +2510,7 @@ class jpPlusPlusTests extends FunSuite {
     })
   }
 
-  test("Ex...") {
+  test("Ex..key1[#]..key2[#]") {
     val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
     val br5: BsonArray = new BsonArray().add(b11)
     val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
@@ -2527,14 +2527,106 @@ class jpPlusPlusTests extends FunSuite {
     val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
     val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
     val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
-    val expression: String = "SpecialEditions[0]"
+    val expression: String = "Book[0]..SpecialEditions[0]"
     val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
     val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
     boson.go(bsonEvent.encodeToBarray())
 
     val expected: Vector[Any] = Vector(b10.encodeToBarray(), b11.encodeToBarray())
     val res = future.join().getValue.asInstanceOf[Vector[Any]]
-    println(s"res: $res")
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex..key1[end]..key2[#]") {
+    val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
+    val br5: BsonArray = new BsonArray().add(b11)
+    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
+    val br4: BsonArray = new BsonArray().add(b10)
+    val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
+    val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val b4: BsonObject = new BsonObject().put("Title", "Scala").put("Pri", 21.5).put("SpecialEditions", br3)
+    val b3: BsonObject = new BsonObject().put("Title", "Java").put("Price", 15.5).put("SpecialEditions", br4)
+    val b8: BsonObject = new BsonObject().put("Title", "C++").put("Price", 12.6).put("SpecialEditions", br5)
+    val br1: BsonArray = new BsonArray().add(b3).add(b4).add(b8)
+    val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
+    val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
+    val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
+    val expression: String = "Book[end]..SpecialEditions[0]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(b11.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex..key1[#]..key2[end]") {
+    val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
+    val br5: BsonArray = new BsonArray().add(b11)
+    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
+    val br4: BsonArray = new BsonArray().add(b10)
+    val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
+    val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val b4: BsonObject = new BsonObject().put("Title", "Scala").put("Pri", 21.5).put("SpecialEditions", br3)
+    val b3: BsonObject = new BsonObject().put("Title", "Java").put("Price", 15.5).put("SpecialEditions", br4)
+    val b8: BsonObject = new BsonObject().put("Title", "C++").put("Price", 12.6).put("SpecialEditions", br5)
+    val br1: BsonArray = new BsonArray().add(b3).add(b4).add(b8)
+    val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
+    val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
+    val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
+    val expression: String = "Book[1]..SpecialEditions[end]"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector(b10.encodeToBarray(),b10.encodeToBarray(),b11.encodeToBarray(),b11.encodeToBarray())
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
+    assert(expected.size === res.size)
+    assertTrue(expected.zip(res).forall {
+      case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)
+      case (e, r) => e.equals(r)
+    })
+  }
+
+  test("Ex..key1[all]..key2[end]..key3[@elem]..key4") {
+    val b11: BsonObject = new BsonObject().put("Title", "C++Machine").put("Price", 38)
+    val br5: BsonArray = new BsonArray().add(b11)
+    val b10: BsonObject = new BsonObject().put("Title", "JavaMachine").put("Price", 39).put("SpecialEditions", br5)
+    val br4: BsonArray = new BsonArray().add(b10)
+    val b9: BsonObject = new BsonObject().put("SpecialEditions", br4).put("Title", "ScalaMachine").put("Price", 40)
+    val br3: BsonArray = new BsonArray().add(b9).add(b10)
+    val b7: BsonObject = new BsonObject().put("Color", "Blue").put("Price", 38)
+    val b6: BsonObject = new BsonObject().put("Color", "White").put("Price", 35)
+    val b5: BsonObject = new BsonObject().put("Color", "Red").put("Price", 48)
+    val b4: BsonObject = new BsonObject().put("Title", "Scala").put("Pri", 21.5).put("SpecialEditions", br3)
+    val b3: BsonObject = new BsonObject().put("Title", "Java").put("Price", 15.5).put("SpecialEditions", br4)
+    val b8: BsonObject = new BsonObject().put("Title", "C++").put("Price", 12.6).put("SpecialEditions", br5)
+    val br1: BsonArray = new BsonArray().add(b3).add(b4).add(b8)
+    val br2: BsonArray = new BsonArray().add(b5).add(b6).add(b7).add(b3)
+    val b2: BsonObject = new BsonObject().put("Book", br1).put("Hatk", br2)
+    val bsonEvent: BsonObject = new BsonObject().put("Store", b2)
+    val expression: String = "Book[all]..SpecialEditions[end]..SpecialEditions[@Price]..Title"
+    val future: CompletableFuture[BsValue] = new CompletableFuture[BsValue]()
+    val boson: Boson = Boson.extractor(expression, (out: BsValue) => future.complete(out))
+    boson.go(bsonEvent.encodeToBarray())
+
+    val expected: Vector[Any] = Vector("C++Machine", "C++Machine","C++Machine")
+    val res = future.join().getValue.asInstanceOf[Vector[Any]]
     assert(expected.size === res.size)
     assertTrue(expected.zip(res).forall {
       case (e: Array[Byte], r: Array[Byte]) => e.sameElements(r)


### PR DESCRIPTION
Implemented expressions: ".", "[end]", "[all]", "[first]", "..Key[@Elem]", "..[#]".

Fixed some bugs(methods: findElement, goThrough, extractFromBsonArray).

Refactored findElements.

Risen Coverage percentage in Scala and Java.


 