### PR TITLE
Rejig dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,8 +116,11 @@ val libraries = Seq(
   "org.scala-lang.modules" % "scala-java8-compat_2.12" % "0.8.0",
   "com.chuusai" % "shapeless_2.12" % "2.3.3",
   "org.parboiled" %% "parboiled" % "2.1.4",
-  "net.jodah" % "typetools" % "0.5.0"
+  "net.jodah" % "typetools" % "0.5.0",
+
+  asm, asmTree, asmAnalysis, asmUtil
 )
+
 
 val testLibraries = Seq(
   "org.scalatest" %% "scalatest" % "3.0.3" % Test withSources(),
@@ -131,7 +134,6 @@ val testLibraries = Seq(
   "io.rest-assured" % "scala-support" % "3.0.6",
   "io.rest-assured" % "rest-assured" % "3.0.6",
   "com.squareup.okhttp3" % "mockwebserver" % "3.9.1",
-//  "com.storm-enroute" %% "scalameter" % "0.8.2",
   "de.undercouch" % "bson4jackson" % "2.7.0"
 )
 
@@ -146,7 +148,6 @@ lazy val bosonCore = project.in(file("boson-core"))
   .settings(basicSettings: _*)
   .settings(javaDoc:  _*)
   .settings(
-    libraryDependencies ++= Dependencies.compile(asm, asmTree, asmAnalysis, asmUtil),
     javacOptions in Test += "-g", // needed for bytecode rewriting
     crossPaths := false,
     autoScalaLibrary := false
@@ -157,7 +158,6 @@ lazy val bosonScala = project.in(file("boson-scala"))
   .settings(basicSettings: _*)
   .settings(javaDoc:  _*)
   .settings(
-    libraryDependencies ++= Dependencies.compile(asm, asmTree, asmAnalysis, asmUtil),
     javacOptions in Test += "-g", // needed for bytecode rewriting
     crossPaths := false,
     autoScalaLibrary := false
@@ -168,7 +168,6 @@ lazy val bosonJava = project.in(file("boson-java"))
   .settings(basicSettings: _*)
   .settings(javaDoc:  _*)
   .settings(
-    libraryDependencies ++= Dependencies.compile(asm, asmTree, asmAnalysis, asmUtil),
     javacOptions in Test += "-g", // needed for bytecode rewriting
     crossPaths := false,
     autoScalaLibrary := false
@@ -180,7 +179,7 @@ lazy val bosonPerformance = project.in(file("boson-performance"))
   .settings(basicSettings: _*)
   .settings(javaDoc:  _*)
   .settings(
-    libraryDependencies ++= Dependencies.compile(asm, asmTree, asmAnalysis, asmUtil, perform),
+    libraryDependencies ++= Dependencies.compile( perform),
     javacOptions in Test += "-g", // needed for bytecode rewriting
     crossPaths := false,
     autoScalaLibrary := false


### PR DESCRIPTION
Remove repeated dependencies in the build file.

Moved asm libraries into fully dependent libraries from the Compile phase only. With the intent that they will be included in the main pom for both main libraries.

Nuked maven and ivy caches to force reload of all libraries to check all dependencies resolve. Which looked good to me.